### PR TITLE
Add research-accountability-pulse routine (read-only v1)

### DIFF
--- a/routines/claude/README.md
+++ b/routines/claude/README.md
@@ -13,9 +13,10 @@ Distinct from `../*.md` markdown playbooks for manual guild processes like funde
 | `coop-intent-pulse.md` | active | Wed 15:30 weekly | Linear only | Initiative status update on `Coop Product Loop & Intent Clarity`; no Issues or Customer Needs |
 | `guild-grant-scout.md` | active | Wed 19:00 weekly | `#funding` + Drive memo | Linear Product (unprojected staging, `funding:*` lifecycle); accepted awards route into a dedicated `Grant Proposal / Award Stewardship` project |
 | `research-synthesis.md` | active | Fri 17:00 weekly | `#research` + Drive memo | Linear Research team (unprojected, `activity:research`) |
+| `research-accountability-pulse.md` | active | Mon & Thu 08:00 twice-weekly | `#research` | Read-only — flags Research team slippage (past-due / stalled / due-soon); writes nothing to Linear |
 | `software-ecology-pulse.md` | source-ready | Mon 19:30 weekly | Linear + Drive + private Discord | Initiative status update on `Software Ecology & Agentic Workflow Health`; requires `Software Ecology Snapshot YYYY-WW` handoff; no Issues or Customer Needs |
 
-Five scheduled runs are active per week, plus the source-ready software ecology pulse. Monday opens with the cross-project synthesis that primes the week; the ecology pulse is intended to follow after a fresh `dev ecology --json --handoff` snapshot has been uploaded or attached as `Software Ecology Snapshot YYYY-WW`. Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before product sync, then handles grants midweek. Friday closes the week with research synthesis. No daily-cadence routines.
+Five weekly runs plus a twice-weekly research-accountability pulse are active, alongside the source-ready software ecology pulse. Monday opens with the cross-project synthesis that primes the week; the ecology pulse is intended to follow after a fresh `dev ecology --json --handoff` snapshot has been uploaded or attached as `Software Ecology Snapshot YYYY-WW`. Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before product sync, then handles grants midweek. Friday closes the week with research synthesis. The read-only research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. No daily-cadence routines.
 
 Anything else previously in this folder has been removed — folded into the surviving routines or cut as noise.
 
@@ -42,11 +43,13 @@ Other guild repos (gardens, impact-reef, gg24-round-explorer, octant-v2(-core), 
 ## Schedule
 
 ```text
+Mon  08:00  research-accountability-pulse
 Mon  18:00  guild-weekly-synthesis
 Mon  19:30  software-ecology-pulse (source-ready; enable after snapshot handoff is configured)
 Tue  16:00  network-steward-intent-pulse
 Wed  15:30  coop-intent-pulse
 Wed  19:00  guild-grant-scout
+Thu  08:00  research-accountability-pulse
 Fri  17:00  research-synthesis
 ```
 
@@ -62,6 +65,7 @@ Fri  17:00  research-synthesis
 | Linear initiative `Software Ecology & Agentic Workflow Health` | software-ecology-pulse | weekly software-ecology health status, no work creation |
 | `#funding` | guild-grant-scout | grant opportunities + proposals |
 | `#research` | research-synthesis | weekly research digest |
+| `#research` | research-accountability-pulse | twice-weekly accountability flags (read-only) |
 
 ## Notification policy
 
@@ -70,6 +74,7 @@ Routines @mention Afo only when his action is required (via `DISCORD_USER_ID_AFO
 - `guild-weekly-synthesis` — only on the `#lead-council` post when at least one risk/decision is overdue
 - `guild-grant-scout` — when a grant deadline is < 7 days out, a new high-fit opportunity scores ≥ 4 on Green Goods, or a stale-prospect decision is needed
 - `research-synthesis` — when an action concretely maps to Green Goods active work
+- `research-accountability-pulse` — tags afo on past-due (🔴) items only
 
 The `#community` excerpt from `guild-weekly-synthesis` never mentions. Discord notifications stay signal-heavy.
 
@@ -97,6 +102,7 @@ All active routines use the `guild-routines` environment at claude.ai/code/routi
 | `software-ecology-pulse` | Google Drive, Linear | Local `dev ecology --json --handoff` snapshot is the primary input and must be uploaded/attached as `Software Ecology Snapshot YYYY-WW`; Linear = initiative status update only; Drive = memo archive; Discord is posted through the configured bot token. No Issues, Customer Needs, PRs, repo edits, deploys, browser sessions, or heavy validation. |
 | `guild-grant-scout` | Google Drive, Google Calendar, Miro, Canva, Linear, PostHog | Linear = `funding:*` lifecycle saved views; accepted awards graduate to a bounded award/delivery project · Drive = drafts + reusable evidence · Calendar = deadlines · Miro = planning context · Canva = existing pitch decks to reference/reuse · PostHog = subtle grant-evidence signal (active gardens, action volume) |
 | `research-synthesis` | Google Drive, Linear, Miro, Google Calendar, Canva, PostHog, Mermaid Chart | Drive + Linear = primary signal (Linear Research team, unprojected) · Miro/Calendar/Canva/PostHog = color enrichment (active week only, never on quiet/silent weeks) · Mermaid = generative for diagrams embedded in Linear Issue bodies |
+| `research-accountability-pulse` | Linear | Linear = read Research team issues for slippage detection (read-only); Discord posted via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |
 
 Gmail is intentionally NOT wired. Personal-inbox content carries too much pollution / noise / private information for any of these routines.
 
@@ -142,6 +148,7 @@ Old label vocabularies (`area:*`, `work:*`, `migration:*`, `automation:*`, `heal
 - `network-steward-intent-pulse` is a status-only routine. It writes to the `Network Presence` initiative and does not create Issues, Customer Needs, projects, Discord posts, Drive docs, or GitHub artifacts.
 - `coop-intent-pulse` is a status-only routine. It writes to the `Coop Product Loop & Intent Clarity` initiative and does not create Issues, Customer Needs, projects, Discord posts, Drive docs, or GitHub artifacts.
 - `software-ecology-pulse` is a status-only routine. It writes to the `Software Ecology & Agentic Workflow Health` initiative, a Dev Guild shared Drive memo, and a private Discord summary. It does not create Issues, Customer Needs, projects, GitHub artifacts, repo edits, deploys, browser sessions, or `.plans` changes.
+- `research-accountability-pulse` is a read-only routine. It posts one `#research` summary flagging overdue / stalled / due-soon owned Research issues (thresholds N=7 / X=3 / M=7, grant pipeline excluded) and writes nothing to Linear in v1. A later v2 may comment/@mention on flagged issues. Canonical rule: the Research team's "Research Accountability — scope, due dates & escalation" Linear Document.
 - Grant lifecycle Issues live in Linear's Product team and are surfaced through saved views over `funding:prospect` / `funding:drafting` / `funding:submitted` / `funding:active-award`. They carry the active `funding:*` label plus `activity:research`, `task:funding-pathway`, the relevant `protocol:*`, and `agent:routine`. On award, an Issue receives `funding:active-award` and moves into a bounded award/delivery project when delivery, reporting, compliance, or funder follow-through needs project-level management.
 - `guild-weekly-synthesis` creates no GitHub or Linear issues. It produces a Drive memo + two Discord posts.
 

--- a/routines/claude/research-accountability-pulse.md
+++ b/routines/claude/research-accountability-pulse.md
@@ -1,0 +1,120 @@
+---
+routine-name: research-accountability-pulse
+trigger:
+  schedule: "0 8 * * 1,4"   # Mon & Thu 08:00 UTC
+max-duration: 30m
+repos: []                    # reads via APIs only; never checks out source
+environment: guild-routines
+network-access: full          # Discord REST (post) + Linear (read)
+env-vars:
+  - DISCORD_BOT_TOKEN
+  - DISCORD_RESEARCH_CHANNEL_ID
+  - DISCORD_USER_ID_AFO
+  - LINEAR_API_KEY
+connectors:
+  - linear
+model: claude-opus-4-8[1m]
+allow-unrestricted-branch-pushes: false
+write-mode: read-only         # v1: Discord summary only; NO Linear writes
+status: active
+---
+
+# Prompt
+
+You are the **research-accountability-pulse** routine for the Greenpill Dev Guild. Twice a week you
+scan the Linear **Research** team for slippage and post one accountability summary to `#research`,
+so the team sees overdue / stalled / due-soon research automatically and afo stops being the chaser.
+
+You are **distinct from `research-synthesis`** (Fri): that routine *creates* accepted research from
+`#research` signal; you *chase* research that already exists. You create nothing — you make slippage visible.
+
+## Scope contract (read first)
+
+- **You are READ-ONLY this version (`write-mode: read-only`).** Query Linear; do NOT create, edit,
+  comment on, label, or reassign any issue. Your only write is ONE Discord post.
+- **Output channel:** `#research` only (`${DISCORD_RESEARCH_CHANNEL_ID}`), via Discord bot-token REST
+  (`Authorization: Bot ${DISCORD_BOT_TOKEN}`). Never post to any other channel; if the channel id is
+  unset, abort and log.
+- **Input:** the Linear **Research** team only. Ignore the Product team in v1.
+- **Out of scope (drop / delegate):** grants & funding lifecycle → `guild-grant-scout`; creating or
+  synthesizing new research → `research-synthesis`. You never file or synthesize work.
+- Thresholds are **N=7, X=3, M=7** and MUST match the rule Document linked in the footer.
+
+## Phase 1 — Pull
+
+List open Research-team issues and keep only **owned commitments** — an issue qualifies only if it has
+**both an assignee and a due date**. Then apply these **hard exclusions**:
+
+- Exclude `statusType ∈ {completed, canceled}`.
+- **Exclude the grant pipeline:** `project = "Grant Scouting"` (`fdd99f00-e9ca-4fb5-b316-89bb6f9f1eff`)
+  OR any `funding:*` label. Grant issues are assignee=afo with hard deadlines but are pipeline tracking
+  owned by `guild-grant-scout`, not research-accountability misses — without this they wrongly flag.
+
+Capture for survivors: identifier, title, url, assignee (display name), dueDate, status/statusType,
+startedAt, updatedAt, labels. Separately count issues labelled `reassigned:overflow` and
+`lane:afo-research` for the tally. Use today's UTC date as the reference.
+
+> Signal note: `updatedAt` is the proxy for "no progress"; **`gitBranchName` is NOT a work signal**
+> (every issue auto-gets one). Real start signal is `startedAt` / `statusType = started`.
+
+## Phase 2 — Flag (each issue lands in at most one bucket; precedence 🔴 > 🟠 > 🟡)
+
+- 🔴 **Past due, not Done** — `dueDate < today` (always flagged).
+- 🟠 **Stalled** — `statusType = started` AND `updatedAt < today − 7d` (N).
+- 🟡 **Due soon, not started** — `statusType ∈ {backlog, unstarted}` AND `today ≤ dueDate ≤ today + 3d` (X).
+
+## Phase 3 — Tally
+
+- afo overflow pickups: count of `reassigned:overflow` (all-time, and within the current cycle).
+- Per-owner throughput: open assigned research issues per person, and how many are currently flagged.
+
+## Phase 4 — Post to #research
+
+**Channel guard:** the only allowed `POST` target is `${DISCORD_RESEARCH_CHANNEL_ID}`. Refuse any plan
+to post elsewhere. If unset, abort and log.
+
+Owner mention: afo via `<@${DISCORD_USER_ID_AFO}>` (the only known Discord id) — tag afo on the 🔴
+past-due items. Name everyone else by Linear display name (no `@` until a name→snowflake map exists).
+Wrap issue URLs in `<...>` to suppress Discord embed unfurls. If every bucket is empty, post the ✅
+all-clear message instead of empty sections.
+
+```
+**📋 Research Accountability — {YYYY-MM-DD}**
+
+🔴 **Past due, not Done** ({n})
+• {ID} {title} — due {date}, {status}, {owner}{ + <@${DISCORD_USER_ID_AFO}> } <{url}>
+
+🟠 **Stalled (no update {N}d+)** ({n})
+• {ID} {title} — last update {date}, {owner} <{url}>
+
+🟡 **Due within {X}d, not started** ({n})
+• {ID} {title} — due {date}, {owner} <{url}>
+
+📈 **Lane & overflow**
+• afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
+• Open assigned research — {owner}: {n} ({k} flagged) · …
+
+— *Read-only pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
+```
+
+All-clear variant (every bucket empty):
+
+```
+**📋 Research Accountability — {YYYY-MM-DD}**
+
+✅ All owned research is on track — nothing past due, stalled, or due in the next {X} days.
+
+📈 **Lane & overflow**
+• afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
+• Open assigned research — {owner}: {n} · …
+
+— *Read-only pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
+```
+
+If the Discord POST fails, log and exit non-zero; never silently drop the run.
+
+## Why this exists
+
+Accountability is structural, not afo's job. coi's lane = Green Goods / Impact Framework; PGSP = afo +
+Matt; afo's deep/cross-cutting research = `lane:afo-research`. The escalation rule (scope → due date →
+flag → reminder → reassign-credited / re-scope) is the linked Document; this routine is its detection layer.


### PR DESCRIPTION
## What

New guild routine **`research-accountability-pulse`** (`routines/claude/research-accountability-pulse.md`) + README registry updates.

Twice-weekly (**Mon & Thu 08:00 UTC**) it scans the Linear **Research** team and posts one summary to `#research` flagging owned issues that are:
- 🔴 **past due & not Done** (always)
- 🟠 **stalled** — in progress, no update in **7 days** (N)
- 🟡 **due soon, not started** — within **3 days** (X)

Plus a lane/overflow tally (`reassigned:overflow`, `lane:afo-research`). Escalation (after **7 days** stalled post-reminder, M) lives in the rule doc.

## Why

Make research accountability **structural** — the system chases, not afo. coi's lane = Green Goods / Impact Framework; PGSP = afo + Matt; afo's deep work = `lane:afo-research`. This is the detection layer for the [Research Accountability rule](https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1).

## Design notes

- **Read-only v1** — queries Linear, posts ONE Discord message, writes nothing to Linear. (v2, later: comment/@mention on flagged issues.)
- **Reuses the `guild-routines` env — no new secrets** (`DISCORD_BOT_TOKEN`, `DISCORD_RESEARCH_CHANNEL_ID`, `DISCORD_USER_ID_AFO`, `LINEAR_API_KEY` already present). Co-located with `research-synthesis`; Linear connector only, Discord via bot-token REST.
- **Grant pipeline excluded** (`project = Grant Scouting` or any `funding:*` label) so it doesn't false-flag grant deadlines owned by `guild-grant-scout`.
- Thresholds **N=7 / X=3 / M=7** are shared with the rule Document — change both together.

## After merge

Create the `Research Accountability Pulse` RemoteTrigger (thin wrapper → this spec) and do a manual read-only run to verify the `#research` post before the schedule takes over. First scheduled fire: Mon Jun 1 08:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)