### PR TITLE
Pulse v2: comment + @mention owner on flagged issues (write-enabled)

### DIFF
--- a/routines/claude/README.md
+++ b/routines/claude/README.md
@@ -13,7 +13,7 @@ Distinct from `../*.md` markdown playbooks for manual guild processes like funde
 | `coop-intent-pulse.md` | active | Wed 15:30 weekly | Linear only | Initiative status update on `Coop Product Loop & Intent Clarity`; no Issues or Customer Needs |
 | `guild-grant-scout.md` | active | Wed 19:00 weekly | `#funding` + Drive memo | Linear Product (unprojected staging, `funding:*` lifecycle); accepted awards route into a dedicated `Grant Proposal / Award Stewardship` project |
 | `research-synthesis.md` | active | Fri 17:00 weekly | `#research` + Drive memo | Linear Research team (unprojected, `activity:research`) |
-| `research-accountability-pulse.md` | active | Mon & Thu 08:00 twice-weekly | `#research` | Read-only — flags Research team slippage (past-due / stalled / due-soon); writes nothing to Linear |
+| `research-accountability-pulse.md` | active | Mon & Thu 08:00 twice-weekly | `#research` + Linear comments | Flags Research team slippage (past-due / stalled / due-soon); comments + `@`-mentions the owner on each flagged issue (idempotent, ~weekly per issue) |
 | `software-ecology-pulse.md` | source-ready | Mon 19:30 weekly | Linear + Drive + private Discord | Initiative status update on `Software Ecology & Agentic Workflow Health`; requires `Software Ecology Snapshot YYYY-WW` handoff; no Issues or Customer Needs |
 
 Five weekly runs plus a twice-weekly research-accountability pulse are active, alongside the source-ready software ecology pulse. Monday opens with the cross-project synthesis that primes the week; the ecology pulse is intended to follow after a fresh `dev ecology --json --handoff` snapshot has been uploaded or attached as `Software Ecology Snapshot YYYY-WW`. Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before product sync, then handles grants midweek. Friday closes the week with research synthesis. The read-only research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. No daily-cadence routines.
@@ -74,7 +74,7 @@ Routines @mention Afo only when his action is required (via `DISCORD_USER_ID_AFO
 - `guild-weekly-synthesis` — only on the `#lead-council` post when at least one risk/decision is overdue
 - `guild-grant-scout` — when a grant deadline is < 7 days out, a new high-fit opportunity scores ≥ 4 on Green Goods, or a stale-prospect decision is needed
 - `research-synthesis` — when an action concretely maps to Green Goods active work
-- `research-accountability-pulse` — tags afo on past-due (🔴) items only
+- `research-accountability-pulse` — Discord: tags afo on past-due (🔴) items; Linear: `@`-mentions each flagged issue's owner in the accountability comment (v2)
 
 The `#community` excerpt from `guild-weekly-synthesis` never mentions. Discord notifications stay signal-heavy.
 
@@ -102,7 +102,7 @@ All active routines use the `guild-routines` environment at claude.ai/code/routi
 | `software-ecology-pulse` | Google Drive, Linear | Local `dev ecology --json --handoff` snapshot is the primary input and must be uploaded/attached as `Software Ecology Snapshot YYYY-WW`; Linear = initiative status update only; Drive = memo archive; Discord is posted through the configured bot token. No Issues, Customer Needs, PRs, repo edits, deploys, browser sessions, or heavy validation. |
 | `guild-grant-scout` | Google Drive, Google Calendar, Miro, Canva, Linear, PostHog | Linear = `funding:*` lifecycle saved views; accepted awards graduate to a bounded award/delivery project · Drive = drafts + reusable evidence · Calendar = deadlines · Miro = planning context · Canva = existing pitch decks to reference/reuse · PostHog = subtle grant-evidence signal (active gardens, action volume) |
 | `research-synthesis` | Google Drive, Linear, Miro, Google Calendar, Canva, PostHog, Mermaid Chart | Drive + Linear = primary signal (Linear Research team, unprojected) · Miro/Calendar/Canva/PostHog = color enrichment (active week only, never on quiet/silent weeks) · Mermaid = generative for diagrams embedded in Linear Issue bodies |
-| `research-accountability-pulse` | Linear | Linear = read Research team issues for slippage detection (read-only); Discord posted via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |
+| `research-accountability-pulse` | Linear | Linear = read Research team issues for slippage + post one accountability comment (`@`-mention owner) per flagged issue; Discord summary via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |
 
 Gmail is intentionally NOT wired. Personal-inbox content carries too much pollution / noise / private information for any of these routines.
 
@@ -148,7 +148,7 @@ Old label vocabularies (`area:*`, `work:*`, `migration:*`, `automation:*`, `heal
 - `network-steward-intent-pulse` is a status-only routine. It writes to the `Network Presence` initiative and does not create Issues, Customer Needs, projects, Discord posts, Drive docs, or GitHub artifacts.
 - `coop-intent-pulse` is a status-only routine. It writes to the `Coop Product Loop & Intent Clarity` initiative and does not create Issues, Customer Needs, projects, Discord posts, Drive docs, or GitHub artifacts.
 - `software-ecology-pulse` is a status-only routine. It writes to the `Software Ecology & Agentic Workflow Health` initiative, a Dev Guild shared Drive memo, and a private Discord summary. It does not create Issues, Customer Needs, projects, GitHub artifacts, repo edits, deploys, browser sessions, or `.plans` changes.
-- `research-accountability-pulse` is a read-only routine. It posts one `#research` summary flagging overdue / stalled / due-soon owned Research issues (thresholds N=7 / X=3 / M=7, grant pipeline excluded) and writes nothing to Linear in v1. A later v2 may comment/@mention on flagged issues. Canonical rule: the Research team's "Research Accountability — scope, due dates & escalation" Linear Document.
+- `research-accountability-pulse` posts one `#research` summary flagging overdue / stalled / due-soon owned Research issues (thresholds N=7 / X=3 / M=7, grant pipeline excluded), and (v2) adds one accountability comment `@`-mentioning the owner on each flagged issue — idempotent (~once/week per issue via a 6-day signed-comment skip), comments only. It never creates / edits / relabels / reassigns issues or changes any field. Canonical rule: the Research team's "Research Accountability — scope, due dates & escalation" Linear Document.
 - Grant lifecycle Issues live in Linear's Product team and are surfaced through saved views over `funding:prospect` / `funding:drafting` / `funding:submitted` / `funding:active-award`. They carry the active `funding:*` label plus `activity:research`, `task:funding-pathway`, the relevant `protocol:*`, and `agent:routine`. On award, an Issue receives `funding:active-award` and moves into a bounded award/delivery project when delivery, reporting, compliance, or funder follow-through needs project-level management.
 - `guild-weekly-synthesis` creates no GitHub or Linear issues. It produces a Drive memo + two Discord posts.
 

--- a/routines/claude/research-accountability-pulse.md
+++ b/routines/claude/research-accountability-pulse.md
@@ -5,7 +5,7 @@ trigger:
 max-duration: 30m
 repos: []                    # reads via APIs only; never checks out source
 environment: guild-routines
-network-access: full          # Discord REST (post) + Linear (read)
+network-access: full          # Discord REST (post) + Linear (read + comment)
 env-vars:
   - DISCORD_BOT_TOKEN
   - DISCORD_RESEARCH_CHANNEL_ID
@@ -15,27 +15,30 @@ connectors:
   - linear
 model: claude-opus-4-8[1m]
 allow-unrestricted-branch-pushes: false
-write-mode: read-only         # v1: Discord summary only; NO Linear writes
+write-mode: write-enabled     # v2: Discord summary + one Linear comment (@mention owner) per flagged issue
 status: active
 ---
 
 # Prompt
 
 You are the **research-accountability-pulse** routine for the Greenpill Dev Guild. Twice a week you
-scan the Linear **Research** team for slippage and post one accountability summary to `#research`,
-so the team sees overdue / stalled / due-soon research automatically and afo stops being the chaser.
+scan the Linear **Research** team for slippage, post one accountability summary to `#research`, and
+drop one nudge comment (`@`-mentioning the owner) on each flagged issue — so the team sees overdue /
+stalled / due-soon research automatically and afo stops being the chaser.
 
 You are **distinct from `research-synthesis`** (Fri): that routine *creates* accepted research from
-`#research` signal; you *chase* research that already exists. You create nothing — you make slippage visible.
+`#research` signal; you *chase* research that already exists. You create no issues — you make slippage visible.
 
 ## Scope contract (read first)
 
-- **You are READ-ONLY this version (`write-mode: read-only`).** Query Linear; do NOT create, edit,
-  comment on, label, or reassign any issue. Your only write is ONE Discord post.
+- **Write scope (`write-mode: write-enabled`, v2):** your only Linear writes are **comments** — one
+  accountability comment, `@`-mentioning the owner, on each flagged issue (Phase 5, idempotent). You do
+  NOT create / edit / relabel / reassign issues, change any field (state, due date, assignee, labels),
+  or comment on non-flagged issues. Plus the ONE Discord summary post.
 - **Output channel:** `#research` only (`${DISCORD_RESEARCH_CHANNEL_ID}`), via Discord bot-token REST
   (`Authorization: Bot ${DISCORD_BOT_TOKEN}`). Never post to any other channel; if the channel id is
   unset, abort and log.
-- **Input:** the Linear **Research** team only. Ignore the Product team in v1.
+- **Input:** the Linear **Research** team only. Ignore the Product team in v1/v2.
 - **Out of scope (drop / delegate):** grants & funding lifecycle → `guild-grant-scout`; creating or
   synthesizing new research → `research-synthesis`. You never file or synthesize work.
 - Thresholds are **N=7, X=3, M=7** and MUST match the rule Document linked in the footer.
@@ -94,7 +97,7 @@ all-clear message instead of empty sections.
 • afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
 • Open assigned research — {owner}: {n} ({k} flagged) · …
 
-— *Read-only pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
+— *Pulse · thresholds N={N}/X={X}/M={M} · commented on {c} flagged issue(s) · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
 ```
 
 All-clear variant (every bucket empty):
@@ -108,13 +111,42 @@ All-clear variant (every bucket empty):
 • afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
 • Open assigned research — {owner}: {n} · …
 
-— *Read-only pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
+— *Pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
 ```
 
 If the Discord POST fails, log and exit non-zero; never silently drop the run.
+
+## Phase 5 — Comment on flagged issues (write-enabled, idempotent)
+
+For **each flagged issue from Phase 2** (🔴 / 🟠 / 🟡 only — never a non-flagged or grant-pipeline issue),
+post ONE Linear comment that `@`-mentions the owner, so the nudge lands in the issue where the work is.
+
+**Idempotency (critical — you run twice weekly; do not spam):** before commenting on an issue, fetch its
+comments and look for the pulse signature `research-accountability-pulse` (any author). Post a new comment
+ONLY if there is no signed comment newer than **6 days** — so a still-flagged issue is nudged at most
+~once per week, not on every Mon + Thu run. Otherwise skip it (already nudged this week) and do not count it.
+
+Comment body (Linear markdown; `@displayName` mentions the assignee):
+
+```
+@{owner displayName} ⏰ **Research accountability** — this issue is {past due & not Done / stalled: no update in {N}d+ / due in {k}d & not started}. Due **{dueDate}**.
+
+Please move it forward or reply here — otherwise flag to afo to re-scope / re-date. Rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>
+
+_— research-accountability-pulse (automated, {YYYY-MM-DD})_
+```
+
+Rules:
+- One comment per flagged issue per run, subject to the 6-day idempotency skip. Never edit, resolve, or
+  delete existing comments; never change issue state, assignee, labels, or due date.
+- If a comment write fails for one issue, log it and continue with the rest; the Discord summary still posts.
+- Count how many comments you actually posted ({c}) and report it in the Discord footer (Phase 4).
+- The Discord summary (Phase 4) runs every time, flagged or all-clear; Phase 5 only acts when issues are flagged.
 
 ## Why this exists
 
 Accountability is structural, not afo's job. coi's lane = Green Goods / Impact Framework; PGSP = afo +
 Matt; afo's deep/cross-cutting research = `lane:afo-research`. The escalation rule (scope → due date →
-flag → reminder → reassign-credited / re-scope) is the linked Document; this routine is its detection layer.
+flag → reminder → reassign-credited / re-scope) is the linked Document; this routine is its detection +
+nudge layer. The terminal escalation (reassign to afo with `reassigned:overflow`, or re-scope) stays a
+human call — this routine never reassigns.


### PR DESCRIPTION
## What

Flips **`research-accountability-pulse`** from read-only to **write-enabled** (v2). Adds **Phase 5**: one Linear comment, `@`-mentioning the owner, on each flagged issue (🔴/🟠/🟡) — so the nudge lands in the issue, not just the `#research` summary.

## Idempotency (the important bit)

The routine runs twice weekly, so Phase 5 must not re-comment the same stale issue every run. Before commenting it checks the issue's comments for the `research-accountability-pulse` signature and **skips if one exists within the last 6 days** → a still-flagged issue is nudged **~once/week**, not on every Mon + Thu run.

## Guardrails

- **Comments only.** Never creates / edits / relabels / reassigns issues or changes state, due date, assignee, or labels.
- Only flagged issues (grant pipeline still excluded); never non-flagged.
- Per-issue write failures are logged and skipped; the Discord summary always posts (now reports the comment count).

## Activation

The live trigger (`trig_01T6eL4Lc9uKebXHXSi63RCd`) is a thin wrapper that re-reads this spec each run, and its Linear connector already permits commenting — so **merging this enables v2 on the next run** (Mon Jun 1 08:06 UTC). No trigger reconfig. v2's new behavior only manifests when an issue is actually flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)