### PR TITLE
fix(grant-scout): stop fabricated prior-grant claims; de-hardcode metrics

### DIFF
--- a/routines/claude/guild-grant-scout.md
+++ b/routines/claude/guild-grant-scout.md
@@ -50,7 +50,7 @@ This routine is **centered on three primary funding targets — Coop, Green Good
 
 What this guild is uniquely positioned to win funding for:
 
-- **Green Goods** — offline-first regenerative documentation platform. Passkey auth, EAS attestations, Arbitrum production deployment with real users (Season One: 13 live gardens), Envio indexer. Strongest grant evidence in the guild — production code + production users.
+- **Green Goods** — offline-first regenerative documentation platform. Passkey auth, EAS attestations, Arbitrum production deployment with real users (Season One pilot live on Arbitrum mainnet), Envio indexer. Strongest grant evidence in the guild — production code + production users.
 - **Coop** — browser extension and PWA for group knowledge capture; Yjs CRDT, Filecoin archival, Safe multisig, **shares Green Goods identity + attestation infrastructure**. Cross-project leverage is real, not aspirational.
 - **PGSP** — Public Goods Staking Protocol. Hoodi testnet onboarding, Lido CSM v3 readiness, validator squad operator support.
 - **Cookie Jar** — funding allowance primitive. DAO tooling, local capital allocation, funding infrastructure.
@@ -440,6 +440,8 @@ If the Drive write fails, still consider the run successful (Discord post + Line
 - **One full draft per run max.** Lightweight outlines for additional urgent opportunities are fine.
 - **Never submit proposals.** Human review owns final submission.
 - **Only claim capabilities that exist in the code today.** Planned work must be labeled as proposed.
+- **Verify factual claims against primary sources before they enter a draft or a Linear Issue.** Track record, prior funding, partnerships, "live" capabilities, and metrics must each trace to a primary source — the grants ledger (`database-export.csv`) for funding status, the indexer/PostHog for metrics, repo code for capabilities. If a claim can't be verified, omit it or mark it "unverified — confirm before submission." Never upgrade an "applied"/"in progress" item to "awarded"/"completed," and never imply a funder relationship the ledger doesn't show. A fabricated track-record claim is a credibility risk with funders and a disqualifier with several (incl. NLnet).
+- **Never hardcode production metrics in a draft.** Garden/gardener/operator/evaluator counts and similar figures drift between runs — pull them from the indexer/PostHog at run time and cite with an "as of {date}" stamp.
 - **Don't share sensitive metrics, unannounced strategy, private counterparties, or budget details in Discord.** Those go to Drive + Linear.
 - **Do not modify source files in any project repo or edit Miro boards or Canva designs.** All design-surface reads are read-only.
 - **PostHog is privacy-public mode only.** Never paste replay URLs, session IDs, distinct IDs, wallet addresses, or any private field. Curated question names only — no raw HogQL in the routine reasoning.

--- a/routines/claude/guild-grant-scout.md
+++ b/routines/claude/guild-grant-scout.md
@@ -59,7 +59,7 @@ What this guild is uniquely positioned to win funding for:
 
 **Distinct angles for funder pitches:** offline-first PWA infrastructure for low-connectivity contexts, on-chain regenerative impact attestation, shared identity primitives across multiple production products, real-user pilot data (Season One gardens on Arbitrum mainnet), evaluator/operator role separation as a governance pattern.
 
-Prior grant work to reference (do not duplicate, iterate): NLnet NGI Zero Commons "Evidence Commons", Octant proposal packs, OSV Grant proposal (Drive), and any Drive docs under grants/proposals.
+Prior grant *materials* to reference for reuse (iterate, do not duplicate): the NLnet NGI Zero Commons draft(s), Octant proposal packs, the OSV Grant proposal, and any Drive docs under grants/proposals. **These are application materials, not awards — never describe them as won, completed, delivered, or as a prior funding relationship unless verified (see Guardrails).** Authoritative funding status lives in the grants ledger (`database-export.csv`, Drive `Funding database export` folder): only rows marked **Completed** are wins. As of 2026-05-31: **NLnet = Applied / pending, never awarded** (no prior NLnet grant or relationship exists — do not imply one); OSV = submitted/awaiting; completed wins citable as track record = Grant Ships R1/R2, Gitcoin GG20–24, Octant Epoch 5 & 10 (Epoch 12 accepted), ReFi-in-Arbitrum, Arbitrum DAO "Building Regenerative Impact".
 
 ## Phase 0: Prior-run recall
 


### PR DESCRIPTION
## Why

The `guild-grant-scout` routine surfaced a **false "prior NLnet Evidence Commons grant (completed)"** claim that nearly rode into a live grant proposal (it reached a Commons draft in Drive). NLnet is **Applied / pending, never awarded** — there is no prior NLnet grant or relationship. This is the kind of easily-checked falsehood that damages credibility with the exact funders we're courting.

## Root cause

The **Project landscape** section listed the NLnet "Evidence Commons" *draft framing* under "Prior grant work to reference," beside genuinely-submitted proposals (OSV, Octant). The routine read it as a real prior grant each run and propagated "Evidence Commons (completed)" into drafts. Compounded by a hardcoded "Season One: 13 live gardens" metric (drifts; conflicts with the run-time-metrics step) and no guardrail requiring factual claims to be verified against a primary source.

## Changes (two commits in this branch)

**Commit 1 — prior-grant reference line → ledger-anchored & status-accurate.** Application materials are explicitly *not* awards; only `database-export.csv` "Completed" rows are wins; NLnet flagged pending; the real completed wins are listed.

**Commit 2 — guardrails + metric de-hardcoding:**
- New Guardrail: **verify factual claims against primary sources** (track record, prior funding, partnerships, "live" capabilities, metrics) before they enter a draft or Linear Issue; never upgrade applied → awarded; never imply a funder relationship the ledger doesn't show. *This is the durable, generalizing fix.*
- New Guardrail: **never hardcode production metrics** — pull garden/gardener counts from the indexer/PostHog at run time with an "as of {date}" stamp.
- Removed the hardcoded "Season One: 13 live gardens" count from the project landscape.

## Verification

Cumulative diff vs `main`: old fabrication string removed; hardcoded "13 live gardens" removed (0 occurrences); all three new markers present; no collateral edits.

Found during a 2026-05-31 grant-research session (write-up: `nlnet-grant-strategy-2026-05-31.md` / `grant-scout-fix-2026-05-31.md` in afo's working dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)