### PR TITLE
Comp playbook: all disciplines + deliverable-vs-continuous (draft)

### DIFF
--- a/routines/scoped-work-compensation.md
+++ b/routines/scoped-work-compensation.md
@@ -1,72 +1,89 @@
 # How the Dev Guild Pays for Scoped Work
 
-> How the guild values and pays for scoped deliverables. The pricing + payment companion to [Funded Work Intake](./funded-work-intake.md), which covers how scoped work is identified and scoped.
+> How the guild values and pays for work across every discipline — engineering, product, marketing, community, research, and growth / BD / funding. Companion to [Funded Work Intake](./funded-work-intake.md), which covers how work is identified and scoped.
 
-**When to use this**: You are a steward, maintainer, or contributor agreeing payment for a scoped piece of work — research, product, design, or marketing. Volunteer contributions use the normal issue/PR flow.
+**When to use this**: You are a steward, maintainer, or contributor agreeing payment for guild work. Volunteer contributions use the normal issue / PR flow.
 
 ## Principle
 
-We pay for **accepted scoped outputs, not for time.** The Linear issue is the ledger: a scoped brief is the unit, and **"Done" (acceptance criteria met + accepted) is the payment event.** Standards stay legible and external — the bar is the acceptance criteria agreed *up front*, not a judgment call at review.
+We pay for **accepted outputs, not for time.** A scoped piece of work is the unit, and **"Done" (acceptance criteria met + accepted) is the payment event.** The bar is the acceptance criteria agreed *up front*, not a judgment call at review.
 
-## The unit of work
+## Two ways we pay
 
-A payable brief carries: one named **Output** artifact · 3–6 **Acceptance criteria** · explicit **Boundary** · **Decision/exit** (done-when + the decision it feeds) · a **value band** (below). No clear artifact + criteria ⇒ not payable yet — it is still in scoping, which is itself paid (Stage 0). Research uses the RESR-4 issue template for this shape.
+- **Deliverable work → scoped brief + band (fixed price).** Most work: a feature, a campaign, a logo, a spec, a research memo, a grant application, an impact report. Scope it, size it, pay on acceptance.
+- **Continuous work → a role / retainer per cycle.** Ongoing coverage that isn't a single artifact — community support, ongoing engineering maintenance, funding tracking. Paid as a **monthly role stipend**, with **extra scoped sessions tracked per hour** (e.g. a dedicated onboarding or support session beyond the baseline).
 
-## Two stages
+The per-discipline table says which mode each discipline uses. The stages, bands, and acceptance flow below describe **deliverable** work.
 
-- **Stage 0 — Paid scoping (Scout band, paid up front).** The deliverable *is the brief*: named artifact + acceptance criteria + boundary + decision/exit + a proposed execution band. This is how a contributor gets "paid to explore" — but the money buys a reviewable output. If Stage 0 yields only vagueness, execution is not funded: a small, bounded spend and a clean exit, not a failed multi-week stipend.
-- **Stage 1 — Execution (banded + tranched).** Once the brief is accepted, fund the work at its band, paid across 2–3 tranches tied to its milestones; the final tranche releases on decision/exit acceptance.
+## The unit (deliverable work)
+
+A payable brief carries one named **Output** · 3–6 **Acceptance criteria** · a **Boundary** · a **Decision/exit** (done-when + the decision it feeds) · a **value band**. No clear artifact + criteria ⇒ not payable yet — it's still in scoping, which is itself paid (Stage 0). Research uses the RESR-4 issue template; the same shape works for any discipline.
+
+## Two stages (deliverable work)
+
+- **Stage 0 — Paid scoping (Scout band, up front).** The deliverable *is the brief*: output + acceptance criteria + boundary + decision/exit + a proposed execution band. How a contributor gets "paid to explore" — but the money buys a reviewable output. If Stage 0 yields only vagueness, execution isn't funded: a small, bounded spend and a clean exit.
+- **Stage 1 — Execution (banded + tranched).** Fund the accepted brief at its band, across 2–3 tranches on its milestones; the final tranche releases on decision/exit acceptance.
 
 ## Sizing — how much
 
-We do not price the insight (you can't); we price **bounded effort at a guild rate set per brief by impact, banded at scope time by the scoper — not by the contributor.** The rate is an internal sizing tool; **work is billed as a fixed price per brief, never open hourly.**
+Price **bounded effort at a guild rate set per brief by impact, banded at scope time by the scoper — not the contributor.** The rate is an internal sizing tool; **work is billed fixed-price per brief, never open hourly** (the exception is continuous-work hourly extras).
 
-- **Guild research rate: $30–60/hr, set per brief by impact.** Low end for routine scouting / low-convergence work; top end for a high-impact synthesis sprint that materially moves the guild forward — we hold a lot of data, and well-aimed synthesis over a focused week is some of the highest-leverage work we have. The range is an explicit early-stage discount below market; it rises as grants grow.
-- **Relativity guardrail:** a research deliverable sizes **below a comparable engineering / integration deliverable** — integration is the heavier lift to implement. Reference: the Hypercerts + DeFi integration ran ~$4,800 (~80–200h, ≈ $24–60/hr). So a research **Deep tops out ~$2.5–3k** and never approaches what a major integration commands.
-- **Bands** — assigned when we scope, before work starts; price = estimated hours × the impact-set rate, then fixed for the brief:
+- **Guild rate: $30–60/hr, set per brief by impact.** Low end for routine work; top end for a high-impact sprint that materially moves the guild forward. An explicit early-stage discount below market; rises as grants grow.
+- **Relativity ladder:** engineering / integration is the heaviest implementation lift → it anchors the top (reference: the Hypercerts + DeFi integration ≈ $4,800, ~80–200h). Product, marketing, research, and growth size *at or below* comparable engineering effort.
+- **Bands** (price = estimated hours × the impact rate, fixed for the brief):
 
-  | Band | Effort | Typical fixed price | Rate posture |
-  |---|---|---|---|
-  | **Scout** | 3–10 hrs | $100–500 | low end ($30–40) — bounded question / spike / Stage 0 scoping |
-  | **Brief** | 12–30 hrs | $500–1,800 | full range by impact — a high-impact week-long synthesis sprint earns the top |
-  | **Deep** | 40–80 hrs | $1,500–3,000 | lower end — large hour-count, kept below a major integration |
+  | Band | Effort | Typical fixed price |
+  |---|---|---|
+  | **Scout** | 3–10 hrs | $100–500 |
+  | **Brief** | 12–30 hrs | $500–1,800 |
+  | **Deep** | 40–80 hrs | $1,500–3,000 |
 
-- **Sanity-check against decision stakes:** what does the decision this unblocks let us do, and how much funding or risk does it touch? **Foundational / reused** work (a taxonomy, an impact-claim spine others build on) earns the top of its band.
-- This dissolves the "contributor won't put a number on the work" problem: **the guild bands it as part of scoping.** No one self-prices.
+  Most product / marketing / research briefs are **Scout–Brief** (clear scope, ~1–2 weeks). **Deep** is reserved for cross-cutting, load-bearing work and stays below a major integration.
+
+## By discipline
+
+| Discipline | Unit / output | "Accepted" means | How it's paid |
+|---|---|---|---|
+| **Engineering** | a shippable change — feature, fix, integration (PR-backed) | merged + meets AC + verified working | deliverable bands; heaviest lift, anchors the top. Ongoing maintenance → continuous role. |
+| **Product** | a scoped product artifact — spec, flow, UX design, brief | approved vs the brief + build-ready | deliverable bands; clear scopes, ~1–2 weeks |
+| **Marketing** | a campaign / content / brand asset (incl. logo, creative) | shipped + meets the brief | deliverable bands; clear scopes, ~1–2 weeks |
+| **Community** | supporting users + members — onboarding, support, engagement | coverage held / session delivered | **monthly support-role stipend** + **per-hour** for extra onboarding or dedicated support sessions |
+| **Research** | a decision-ready artifact — memo, taxonomy, readiness plan | AC met + decision usable (incl. a rigorous "no-go") | deliverable bands (Scout / Brief / Deep), sized below engineering |
+| **Growth / BD / Funding** | grant application, impact report, partnership, funding tracking | submitted / delivered / partnership advanced | funding-pegged bands (a fraction of the funding unblocked); grant **sourcing + tracking** are pipeline / continuous |
+
+**Design is not a separate lane** — product / UX design is a Product artifact; brand / creative (logos, assets) is a Marketing artifact.
 
 ## Controlling total spend
 
-The rate sizes a brief; it does not bound the budget. What keeps research affordable as the team grows:
+The rate sizes a brief; it does not bound the budget. What keeps spend affordable:
 
-- **Grant-tied envelope.** Research is funded as a capped line-item inside the grant or initiative it supports (a set amount / % per cycle), not an open pool — and we prefer research that helps unblock the funding it draws from.
-- **WIP cap: ≤ 2–3 *paid* briefs active at once**, regardless of headcount. Five contributors do not mean five paid briefs.
-- **Most research stays unpaid signal.** The #research channel and the weekly synthesis routine capture raw exploration for free; a *paid* brief is the exception, reserved for a scoped, decision-critical question.
+- **Grant-tied envelope — the actual spend bound.** Paid work is funded as a capped line-item inside the grant or initiative it supports (a set amount / % per cycle), not an open pool — and we prefer work that helps unblock the funding it draws from.
+- **WIP cap for focus.** Keep a small number of paid deliverable briefs active per lane (≤ 2–3) so work finishes; the envelope, not headcount, is what caps total spend.
+- **Most exploration stays unpaid signal.** Discussion channels and the weekly synthesis capture raw exploration for free; a *paid* brief is the exception, reserved for scoped, decision- or ship-critical work.
 
 ## Accept, revise, escalate
 
 - **Accepted = acceptance criteria met**, reviewed by the scoping steward or a **designated / external evaluator** — acceptance should not be one person's solo subjective call.
 - Short of criteria → **one revision round** (request-changes + a short re-due).
-- Still short → escalate: **re-scope / split** (partial credit for the accepted portion) **or reassign.** **Budget follows the output:** if someone else picks it up, the unearned tranche moves with it. The guild pays once, to whoever clears the bar.
-
-## Research vs product
-
-Product and research share this spine; research differs in a few ways:
-
-- **Horizon & uncertainty** — research is longer and fuzzier → smaller Stage 0, more milestone-based Stage 1.
-- **Negative results are paid in full.** A rigorously-executed brief that concludes "no-go" is fully delivered and fully paid. We pay for *rigor against the criteria*, never for a particular answer — otherwise we pay people to tell us what we want to hear.
-- **Two valuation paths** — research feeding a product/strategy decision → band × rate; research feeding **funding** (proposal credibility, grant pipeline) → peg to a fraction of the funding it unblocks. Acceptance is "criteria met + decision usable," not artifact length.
-- **Relativity holds** — research sizes *below* the comparable engineering / integration work, which is the heavier implementation lift.
+- Still short → escalate: **re-scope / split** (partial credit for the accepted portion) **or reassign.** **Budget follows the output:** if someone else finishes it, the unearned tranche moves with it. The guild pays once, to whoever clears the bar.
 
 ## Trust over time
 
-First engagement: more up front, more support. Future front-loading is **earned by delivery**; repeated misses mean quiet non-renewal, not confrontation. Cash is not the whole package — GreenWill recognition, credited overflow pickups (`reassigned:overflow`), and a rising track record are part of how the guild values contribution. As budgets grow the **$30–60 range itself rises toward market** on a stated trigger (e.g., per major grant won), and proven delivery moves a contributor toward the top of the current range.
+First engagement: more up front, more support. Future front-loading is **earned by delivery**; repeated misses mean quiet non-renewal, not confrontation. Cash isn't the whole package — recognition (GreenWill), credited overflow pickups (`reassigned:overflow`), and a rising track record all count. As budgets grow the **$30–60 range itself rises toward market** on a stated trigger (e.g. per major grant won), and proven delivery moves a contributor toward the top of the current range.
+
+## In Linear
+
+- A paid **deliverable brief** lives as an issue on its team (Product or Research), carrying the **scoped-brief shape** (the RESR-4 template), an **`activity:*` label** for its discipline (`build` / `design` / `research` / `architecture` / …), and its **band** noted on the issue.
+- **Growth / BD / Funding** runs through the `funding:*` lifecycle labels + `task:funding-pathway` + the Grant Scouting project (sourced by the `guild-grant-scout` routine).
+- **Continuous roles** (community support, maintenance) are a recurring arrangement, tracked separately from per-brief issues.
+- The **research-accountability pulse + rule** govern dated, owned deliverable issues — Research today, extendable to Product.
 
 ## Related
 
-- [Funded Work Intake](./funded-work-intake.md) — how scoped paid work is identified and scoped; this playbook is its pricing/payment layer.
-- [Grant Application](./grant-application.md) — funding-source-side process.
-- **Research Accountability** rule (Linear Document, Research team) — scope → due date → pulse flags → reminder → escalation; this playbook prices and pays the same flow.
+- [Funded Work Intake](./funded-work-intake.md) — how scoped paid work is identified and scoped; this playbook is its pricing / payment layer.
+- [Grant Application](./grant-application.md) — funding-source-side process for the Growth / BD / Funding lane.
+- **Research Accountability** rule (Linear Document, Research team) — scope → due date → pulse → escalation; this playbook prices and pays the same flow.
 
 ---
 
-*Status: draft for steward review. Rate = **$30–60/hr range, set per brief by impact**, research sized below comparable integration work; band $-ranges are defaults to tune against runway, and the per-cycle research envelope is set per grant. Natural first pilot — coi's scoped Impact Framework work (RESR-6 → RESR-12), introduced as "how we pay for scoped work now," not a crackdown.*
+*Status: draft for steward review. Disciplines: engineering · product · marketing · community · research · growth/BD/funding. Deliverable work = scoped brief + $30–60/hr impact-set bands (research sized below integration); community = monthly support role + hourly extras; product/marketing = artifact briefs, ~1–2 weeks. Spend bound = the per-grant envelope.*

--- a/routines/scoped-work-compensation.md
+++ b/routines/scoped-work-compensation.md
@@ -29,7 +29,7 @@ A payable brief carries one named **Output** · 3–6 **Acceptance criteria** ·
 Price **bounded effort at a guild rate set per brief by impact, banded at scope time by the scoper — not the contributor.** The rate is an internal sizing tool; **work is billed fixed-price per brief, never open hourly** (the exception is continuous-work hourly extras).
 
 - **Guild rate: $30–60/hr, set per brief by impact.** Low end for routine work; top end for a high-impact sprint that materially moves the guild forward. An explicit early-stage discount below market; rises as grants grow.
-- **Relativity ladder:** engineering / integration is the heaviest implementation lift → it anchors the top (reference: the Hypercerts + DeFi integration ≈ $4,800, ~80–200h). Product, marketing, research, and growth size *at or below* comparable engineering effort.
+- **Relativity ladder:** engineering / integration is the heaviest implementation lift → it anchors the top (a major integration is ~80–200h of senior work). Product, marketing, research, and growth size *at or below* comparable engineering effort.
 - **Bands** (price = estimated hours × the impact rate, fixed for the brief):
 
   | Band | Effort | Typical fixed price |


### PR DESCRIPTION
Generalizes the comp playbook from research-only to the **full guild taxonomy**, per steward discussion.

- **Disciplines:** engineering · product · marketing · **community** (split from marketing) · research · **growth / BD / funding** (new).
- **Two ways we pay:** *deliverable* work (scoped brief + band, fixed price) vs *continuous* work (monthly role + hourly extras — e.g. community support).
- **By-discipline table** — each discipline's unit, what "accepted" means, and comp shape (community = monthly role + per-hour extras; product/marketing = artifact briefs ~1–2 wks; eng anchors the relativity ladder; research sized below it; growth/BD/funding pegged to funding).
- **Design dropped as a standalone lane** — product/UX = Product artifact, brand/creative = Marketing artifact.
- **Envelope (not headcount) is the spend bound**; WIP cap is for focus. Added an **In Linear** mapping (teams, `activity:*` / `funding:*` labels, RESR-4 brief shape).

**Open for review — not auto-merged.** Status: draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)