### PR TITLE
Pulse: also scan Product scoped briefs (band:*)

### DIFF
--- a/routines/claude/research-accountability-pulse.md
+++ b/routines/claude/research-accountability-pulse.md
@@ -22,7 +22,7 @@ status: active
 # Prompt
 
 You are the **research-accountability-pulse** routine for the Greenpill Dev Guild. Twice a week you
-scan the Linear **Research** team for slippage, post one accountability summary to `#research`, and
+scan the Linear **Research** team — plus scoped (`band:*`-labelled) briefs on **Product** — for slippage, post one accountability summary to `#research`, and
 drop one nudge comment (`@`-mentioning the owner) on each flagged issue — so the team sees overdue /
 stalled / due-soon research automatically and afo stops being the chaser.
 
@@ -38,15 +38,19 @@ You are **distinct from `research-synthesis`** (Fri): that routine *creates* acc
 - **Output channel:** `#research` only (`${DISCORD_RESEARCH_CHANNEL_ID}`), via Discord bot-token REST
   (`Authorization: Bot ${DISCORD_BOT_TOKEN}`). Never post to any other channel; if the channel id is
   unset, abort and log.
-- **Input:** the Linear **Research** team only. Ignore the Product team in v1/v2.
+- **Input:** the **Research** team (all owned + dated issues) **plus Product-team issues that carry a `band:*` label** (paid scoped briefs only — never Product's whole backlog).
 - **Out of scope (drop / delegate):** grants & funding lifecycle → `guild-grant-scout`; creating or
   synthesizing new research → `research-synthesis`. You never file or synthesize work.
 - Thresholds are **N=7, X=3, M=7** and MUST match the rule Document linked in the footer.
 
 ## Phase 1 — Pull
 
-List open Research-team issues and keep only **owned commitments** — an issue qualifies only if it has
-**both an assignee and a due date**. Then apply these **hard exclusions**:
+List open issues from **both teams** and keep only **owned commitments** — an issue qualifies only if it has **both an assignee and a due date**:
+
+- **Research team** — all such issues.
+- **Product team** — only those that *also* carry a **`band:*` label** (a paid scoped brief). This keeps Product's large backlog out — we chase paid briefs, not everything.
+
+Then apply these **hard exclusions** to both teams:
 
 - Exclude `statusType ∈ {completed, canceled}`.
 - **Exclude the grant pipeline:** `project = "Grant Scouting"` (`fdd99f00-e9ca-4fb5-b316-89bb6f9f1eff`)
@@ -74,7 +78,7 @@ startedAt, updatedAt, labels. Separately count issues labelled `reassigned:overf
 ## Phase 4 — Post to #research
 
 **Channel guard:** the only allowed `POST` target is `${DISCORD_RESEARCH_CHANNEL_ID}`. Refuse any plan
-to post elsewhere. If unset, abort and log.
+to post elsewhere. If unset, abort and log. (Research `RESR-` and Product `PRD-` flags both post to `#research` for now — the identifier shows the team; a dedicated dev/product channel can be added later via a new channel-id secret.)
 
 Owner mention: afo via `<@${DISCORD_USER_ID_AFO}>` (the only known Discord id) — tag afo on the 🔴
 past-due items. Name everyone else by Linear display name (no `@` until a name→snowflake map exists).


### PR DESCRIPTION
Extends the research-accountability pulse to flag **owned + dated Product issues carrying a `band:*` label** (paid scoped briefs), in addition to all Research-team owned+dated issues. Product's full backlog stays out by design; grant pipeline still excluded. Both teams' flags post to #research for now (the `RESR-`/`PRD-` identifier shows the team). Inert until Product briefs are banded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)