### PR TITLE
docs: register comp taxonomy (band/activity labels, Scoped Brief template, cross-links)

### DIFF
--- a/docs/linear-operating-model.md
+++ b/docs/linear-operating-model.md
@@ -39,15 +39,20 @@ Use these label families for Linear Issues:
 
 - `protocol:*` — project or protocol surface, such as `protocol:green-goods`, `protocol:coop`, `protocol:network`, `protocol:cookie-jar`, `protocol:pgsp`, `protocol:greenwill`, or `protocol:tas-hub`.
 - `package:*` — code package surface when useful, such as `package:client`, `package:admin`, `package:contracts`, `package:indexer`, or `package:agent`.
-- `activity:*` — work mode, such as `activity:build`, `activity:research`, `activity:design`, `activity:qa`, or `activity:maintenance`.
+- `activity:*` — work mode, such as `activity:build`, `activity:research`, `activity:design`, `activity:qa`, `activity:maintenance`, `activity:marketing`, `activity:community`, or `activity:growth`.
 - `task:*` — user-task semantics, such as `task:funding-pathway`, `task:evidence`, `task:access-participation`, `task:data-input`, or `task:local-onboarding`.
 - `funding:*` — grant/funding lifecycle: `funding:prospect`, `funding:drafting`, `funding:submitted`, `funding:active-award`.
 - `source:*` — originating signal, such as `source:github`, `source:discord`, `source:telegram`, `source:drive`, or `source:plans`.
 - `agent:*` — authored or maintained by a routine or agent, such as `agent:claude`, `agent:codex`, or `agent:copilot`.
+- `band:*` — value band for a paid scoped brief (sizing for compensation): `band:scout`, `band:brief`, or `band:deep`. See the [scoped-work compensation playbook](../routines/scoped-work-compensation.md).
 
 Linear enforces exclusive child labels within grouped families. Pick the primary child label for each family rather than applying several `task:*`, `activity:*`, `protocol:*`, or `package:*` labels to the same issue.
 
 Do not recreate retired GitHub-era label families in Linear. In particular, avoid `area:*`, `work:*`, `migration:*`, `automation:*`, `health:*`, `grant:*`, and `source:linear`.
+
+## Scoped work, bands & accountability
+
+Paid work is scoped, sized, and paid per the [How the Dev Guild Pays for Scoped Work](../routines/scoped-work-compensation.md) playbook: a **scoped brief** (Output · Acceptance criteria · Boundary · Decision/exit) carries a `band:*` label and an `activity:*` discipline label, and "Done" (accepted) is the payment event. Dated, owned briefs are chased by the `research-accountability-pulse` routine under the **Research Accountability** rule (scope → due date → pulse → escalation), kept as a Linear Document in the Research Operations project. Continuous roles (e.g. community support) are a monthly arrangement rather than per-brief.
 
 ## Funding lifecycle
 

--- a/docs/linear-templates.md
+++ b/docs/linear-templates.md
@@ -8,7 +8,7 @@ Linear UI templates may exist, but Codex and other connector-based agents cannot
 
 - Customer Needs are raw customer, partner, funder, garden, cohort, or internal-ops signal. They are not commitments to build.
 - Linear Issues are accepted units of work with a clear next action. Product issues track accepted delivery, QA, maintenance, funding, and protocol work. Research issues track accepted research tasks.
-- Grouped child labels are exclusive in Linear. Choose the primary child label for each family, such as one `task:*`, one `activity:*`, one `protocol:*`, and one `package:*` where applicable.
+- Grouped child labels are exclusive in Linear. Choose the primary child label for each family, such as one `task:*`, one `activity:*`, one `protocol:*`, one `package:*` where applicable, and one `band:*` for payable scoped briefs.
 - Projects are bounded containers made from multiple related stories, issues, or research tasks. Do not create a project for a single loose idea unless it is a deliberate scoping project.
 - Initiatives are outcome arcs. They group projects around a durable strategic outcome, not around a repo, inbox, or imported board.
 - Do not route new work into completed, canceled, staging, or retired projects such as `Green Goods`, `Coop`, `Network Website`, `Cookie Jar`, or `Story Board`.
@@ -181,6 +181,32 @@ Research source: {#research week of YYYY-MM-DD, partner conversation, Drive memo
 ## Status
 
 Accepted - research time is committed to investigating this. Graduates into a bounded delivery project only if the investigation produces work the team commits to ship.
+```
+
+## Linear Scoped Brief - Payable Deliverable
+
+Use when a piece of work is scoped for **payment** (any discipline). This is the deliverable shape behind the [compensation playbook](../routines/scoped-work-compensation.md). The *Accepted Research Task* above is the lighter acceptance-bar intake; a paid **Stage-0 scoping** pass turns an accepted task into this payable brief.
+
+Title: `{short deliverable title}`
+
+Labels: one `activity:*` (discipline), one `band:*` (`scout` / `brief` / `deep`), primary relevant `protocol:*`, and `task:*` where applicable. Set a due date and assignee.
+
+```markdown
+## Output
+
+{the one concrete artifact this brief produces}
+
+## Acceptance criteria
+
+* {3–6 checkable bullets — what "done + accepted" means}
+
+## Boundary
+
+{what is explicitly out of scope}
+
+## Decision / exit
+
+Done when {condition}, reviewed by {steward / designated evaluator}. Feeds: {the decision this unblocks}.
 ```
 
 ## Linear Funding Issue - Grant Lifecycle

--- a/routines/claude/README.md
+++ b/routines/claude/README.md
@@ -126,7 +126,8 @@ All Linear writes use the canonical label scheme:
 
 - `protocol:*` — protocol/project (`protocol:green-goods`, `protocol:coop`, `protocol:pgsp`, `protocol:greenwill`, `protocol:network`, `protocol:tas`)
 - `package:*` — code package surface. Green Goods packages: `package:client`, `package:admin`, `package:shared`, `package:contracts`, `package:indexer`, `package:agent`, `package:docs`. Coop packages: `package:app`, `package:api`, `package:extension`. (Each protocol owns its own package set; `protocol:*` partitions the namespace.)
-- `activity:*` — activity type (`activity:research`, `activity:qa`, `activity:maintenance`, `activity:architecture`, `activity:build`, `activity:design`)
+- `activity:*` — activity type (`activity:research`, `activity:qa`, `activity:maintenance`, `activity:architecture`, `activity:build`, `activity:design`, `activity:marketing`, `activity:community`, `activity:growth`)
+- `band:*` — value band for a paid scoped brief (sizing for comp): `band:scout`, `band:brief`, `band:deep`. See the scoped-work compensation playbook (`routines/scoped-work-compensation.md`).
 - `task:*` — user-task semantics (`task:funding-pathway`, `task:evidence`, `task:access-participation`, `task:reputation-identity`, `task:data-input`, `task:local-onboarding`, `task:evaluator-review`)
 - `funding:*` — funding lifecycle (`funding:prospect`, `funding:drafting`, `funding:submitted`, `funding:active-award`)
 - `source:*` — provenance of the originating signal (`source:discord`, `source:telegram`, `source:drive`, `source:plans`, `source:github`)


### PR DESCRIPTION
Closes the documentation-drift gaps from the comp scaffolding:
- Register `band:scout/brief/deep` + `activity:marketing/community/growth` in the operating model, templates routing, and routines README taxonomy.
- Add a **Scoped Brief — Payable Deliverable** template to the canonical templates doc, reconciled with the existing *Accepted Research Task* (accept-to-investigate → Stage-0 scopes into a payable brief).
- Cross-link the comp playbook + Research Accountability rule from the operating model.

Doc hygiene only — no rates or names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)