### PR TITLE
Retire lane:/reassigned: from comp + accountability docs

### DIFF
--- a/routines/claude/research-accountability-pulse.md
+++ b/routines/claude/research-accountability-pulse.md
@@ -58,8 +58,7 @@ Then apply these **hard exclusions** to both teams:
   owned by `guild-grant-scout`, not research-accountability misses — without this they wrongly flag.
 
 Capture for survivors: identifier, title, url, assignee (display name), dueDate, status/statusType,
-startedAt, updatedAt, labels. Separately count issues labelled `reassigned:overflow` and
-`lane:afo-research` for the tally. Use today's UTC date as the reference.
+startedAt, updatedAt, labels. Use today's UTC date as the reference.
 
 > Signal note: `updatedAt` is the proxy for "no progress"; **`gitBranchName` is NOT a work signal**
 > (every issue auto-gets one). Real start signal is `startedAt` / `statusType = started`.
@@ -72,8 +71,7 @@ startedAt, updatedAt, labels. Separately count issues labelled `reassigned:overf
 
 ## Phase 3 — Tally
 
-- afo overflow pickups: count of `reassigned:overflow` (all-time, and within the current cycle).
-- Per-owner throughput: open assigned research issues per person, and how many are currently flagged.
+- Per-owner throughput: open assigned issues per person, and how many are currently flagged.
 
 ## Phase 4 — Post to #research
 
@@ -97,9 +95,8 @@ all-clear message instead of empty sections.
 🟡 **Due within {X}d, not started** ({n})
 • {ID} {title} — due {date}, {owner} <{url}>
 
-📈 **Lane & overflow**
-• afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
-• Open assigned research — {owner}: {n} ({k} flagged) · …
+📈 **Throughput**
+• Open assigned ({owner}): {n} ({k} flagged) · …
 
 — *Pulse · thresholds N={N}/X={X}/M={M} · commented on {c} flagged issue(s) · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
 ```
@@ -111,9 +108,8 @@ All-clear variant (every bucket empty):
 
 ✅ All owned research is on track — nothing past due, stalled, or due in the next {X} days.
 
-📈 **Lane & overflow**
-• afo overflow pickups (reassigned:overflow): {n} all-time · {n} this cycle
-• Open assigned research — {owner}: {n} · …
+📈 **Throughput**
+• Open assigned ({owner}): {n} · …
 
 — *Pulse · thresholds N={N}/X={X}/M={M} · rule: <https://linear.app/greenpill-dev-guild/document/research-accountability-scope-due-dates-and-escalation-7603e2acaff1>*
 ```
@@ -150,7 +146,6 @@ Rules:
 ## Why this exists
 
 Accountability is structural, not afo's job. coi's lane = Green Goods / Impact Framework; PGSP = afo +
-Matt; afo's deep/cross-cutting research = `lane:afo-research`. The escalation rule (scope → due date →
+Matt; afo's deep/cross-cutting research is a saved view (Research team, assignee = afo), not a label. The escalation rule (scope → due date →
 flag → reminder → reassign-credited / re-scope) is the linked Document; this routine is its detection +
-nudge layer. The terminal escalation (reassign to afo with `reassigned:overflow`, or re-scope) stays a
-human call — this routine never reassigns.
+nudge layer. The terminal escalation (reassign to afo, credited via the comp flow since the unearned tranche follows the work, or re-scope) stays a human call; this routine never reassigns.

--- a/routines/scoped-work-compensation.md
+++ b/routines/scoped-work-compensation.md
@@ -69,7 +69,7 @@ The rate sizes a brief; it does not bound the budget. What keeps spend affordabl
 
 ## Trust over time
 
-First engagement: more up front, more support. Future front-loading is **earned by delivery**; repeated misses mean quiet non-renewal, not confrontation. Cash isn't the whole package — recognition (GreenWill), credited overflow pickups (`reassigned:overflow`), and a rising track record all count. As budgets grow the **$30–60 range itself rises toward market** on a stated trigger (e.g. per major grant won), and proven delivery moves a contributor toward the top of the current range.
+First engagement: more up front, more support. Future front-loading is **earned by delivery**; repeated misses mean quiet non-renewal, not confrontation. Cash isn't the whole package: recognition (GreenWill), credited overflow pickups (the unearned tranche follows the work to whoever finishes it), and a rising track record all count. As budgets grow the **$30–60 range itself rises toward market** on a stated trigger (e.g. per major grant won), and proven delivery moves a contributor toward the top of the current range.
 
 ## In Linear
 


### PR DESCRIPTION
Per steward decision, `lane:afo-research` and `reassigned:overflow` are too specific to keep as labels. Lanes become a **saved view** (Research team, assignee = afo); overflow **credit rides the comp flow** (unearned tranche follows the work). Removes the label references from the pulse spec (tally is now per-owner throughput), the comp playbook, and the 'why' section. Actual label deletion is a Linear UI step (MCP is create-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)