### PR TITLE
fix(grant-scout): harden Linear access, dedup, and anti-fabrication (supersedes #19)

### DIFF
--- a/routines/claude/guild-grant-scout.md
+++ b/routines/claude/guild-grant-scout.md
@@ -16,7 +16,6 @@ env-vars:
   - DISCORD_BOT_TOKEN
   - DISCORD_FUNDING_CHANNEL_ID
   - DISCORD_USER_ID_AFO
-  - LINEAR_API_KEY
   - POSTHOG_PROJECT_API_KEY
   - POSTHOG_HOST
 connectors:
@@ -38,9 +37,10 @@ This routine is **centered on three primary funding targets — Coop, Green Good
 
 ## Setup
 
-- `DISCORD_BOT_TOKEN`, `DISCORD_FUNDING_CHANNEL_ID`, `DISCORD_USER_ID_AFO`, `LINEAR_API_KEY`, `POSTHOG_PROJECT_API_KEY`, and `POSTHOG_HOST` are in the environment.
+- `DISCORD_BOT_TOKEN`, `DISCORD_FUNDING_CHANNEL_ID`, `DISCORD_USER_ID_AFO`, `POSTHOG_PROJECT_API_KEY`, and `POSTHOG_HOST` are in the environment.
 - Connectors available: Google Drive, Google Calendar, Miro, **Canva**, Linear, **PostHog**. (Gmail is intentionally NOT wired — personal-inbox pollution risk.)
-- **Linear is the canonical surface for grant lifecycle.** Prospects/drafts/submissions live as Linear Product Issues surfaced through saved views over the canonical `funding:*` lifecycle labels. **Awarded grants graduate** into a bounded award/delivery project when delivery, reporting, compliance, or funder follow-through needs project-level management. Resolve team/project/label IDs by name at the start of every run.
+- **Linear is the canonical surface for grant lifecycle.** Non-awarded grants (prospect / drafting / submitted) live as Issues in the **Research team's `Grant Scouting` project**, tracked with the canonical `funding:*` lifecycle labels. **Awarded grants graduate** to the **Product team** into a bounded award/delivery project when delivery, reporting, compliance, or funder follow-through needs project-level management. Because awards live in Product and everything else in Research, **always read `funding:*` workspace-wide — never scope a read to a single team** (a team-scoped read silently misses half the pipeline and causes already-tracked programs to re-surface as "NEW"). Resolve team/project/label IDs by name at the start of every run.
+- **Reach Linear through the Linear connector** — the default and only Linear path; **no Linear API key is stored for this routine.** Use the connector to read and write the `funding:*` lifecycle. It is an OAuth integration that can lapse between runs; if it is unauthed or unreachable you have lost the canonical dedup + write surface, so **do not scout** — follow the **fail-closed rule in Phase 0** (post one status line flagging that the connector needs re-authorization, then exit). Never scout without Linear, and never fall back to scouting blind.
 - **Canva** is read-only enrichment. Use to find existing pitch decks / slides that can inform new proposals or be referenced for visual narrative continuity. Reject step: drop personal-folder Canva content, drop designs whose title contains `'WEFA'` or `'wefa.world'`.
 - **PostHog** is a subtle, secondary evidence signal — never the primary discovery surface. Use for grant evidence enrichment in Phase 2 (fit assessment) and Phase 3 (proposal drafting) only. Privacy mode: public. Never paste replay URLs, session IDs, distinct IDs, or wallet addresses anywhere. **When using the PostHog connector, call `switch-project` to the App project (`163591`) before any query** — the connector defaults to the wrong project and silently returns zero, which would make evidence enrichment quietly empty without flagging it.
 - Active project repos cloned via `sources` for read-only context: `green-goods`, `coop`, `network-website`, `cookie-jar`, `TAS-Hub`, `.github`.
@@ -50,7 +50,7 @@ This routine is **centered on three primary funding targets — Coop, Green Good
 
 What this guild is uniquely positioned to win funding for:
 
-- **Green Goods** — offline-first regenerative documentation platform. Passkey auth, EAS attestations, Arbitrum production deployment with real users (Season One: 13 live gardens), Envio indexer. Strongest grant evidence in the guild — production code + production users.
+- **Green Goods** — offline-first regenerative documentation platform. Passkey auth, EAS attestations, Arbitrum production deployment with real users (Season One pilot live on Arbitrum — pull current garden / gardener / operator counts at runtime per the Phase 2/3 metrics step; cite "as of {date}", never a hardcoded number), Envio indexer. Strongest grant evidence in the guild — production code + production users.
 - **Coop** — browser extension and PWA for group knowledge capture; Yjs CRDT, Filecoin archival, Safe multisig, **shares Green Goods identity + attestation infrastructure**. Cross-project leverage is real, not aspirational.
 - **PGSP** — Public Goods Staking Protocol. Hoodi testnet onboarding, Lido CSM v3 readiness, validator squad operator support.
 - **Cookie Jar** — funding allowance primitive. DAO tooling, local capital allocation, funding infrastructure.
@@ -59,13 +59,22 @@ What this guild is uniquely positioned to win funding for:
 
 **Distinct angles for funder pitches:** offline-first PWA infrastructure for low-connectivity contexts, on-chain regenerative impact attestation, shared identity primitives across multiple production products, real-user pilot data (Season One gardens on Arbitrum mainnet), evaluator/operator role separation as a governance pattern.
 
-Prior grant work to reference (do not duplicate, iterate): NLnet NGI Zero Commons "Evidence Commons", Octant proposal packs, OSV Grant proposal (Drive), and any Drive docs under grants/proposals.
+Prior grant *materials* to reference for reuse (iterate, do not duplicate): the NLnet NGI Zero Commons draft(s), Octant proposal packs, the OSV Grant proposal, and Drive docs under grants/proposals. **These are application materials, not awards.** Before citing ANY grant as prior/won/completed, verify status in the grants ledger (`database-export.csv` / Drive `Funding database export`): only "Completed" rows are wins. As of 2026-06: NLnet = **Applied/pending, never awarded** (no prior NLnet relationship — there is **no** "Evidence Commons" grant); OSV = submitted/awaiting. Treat every funding claim as unverified until the ledger confirms it (see the verify-claims guardrail).
 
 ## Phase 0: Prior-run recall
 
+### Preflight (run this first — it gates the whole run)
+
+At run start, verify each surface you depend on and record a one-line health status (carry it into the Phase 6 memo, and into the Phase 5 post if anything is degraded):
+
+- **Linear (REQUIRED):** confirm the Linear connector is authorized and reachable — a probe query (e.g. fetch one issue by `funding:*` label) returns data, not an auth error.
+- **Secondary** (Drive, Discord, Calendar, Miro, Canva, PostHog): probe each; note which are reachable.
+
+**Fail-closed rule (hard).** Linear is the canonical dedup *and* write surface. If the Linear preflight fails — the connector is unauthed or unreachable — **you cannot dedup, so you must not scout.** Do exactly this and nothing else: post a single line to `#funding` — `Guild Grant Scout {date}: Linear connector unavailable (needs re-authorization) — skipping this run to avoid duplicate/fabricated opportunities. Action needed: re-auth the Linear connector.` — write a Phase 6 memo noting the failed preflight, and exit. **Never** emit a "new opportunities" list, fit scores, or a pipeline snapshot from a run that could not load `KNOWN_PROGRAMS`: a degraded run that stays silent is correct; a degraded run that invents opportunities is the exact failure this rule exists to prevent. If only a *secondary* surface is down, continue but record the coverage gap.
+
 Before scouting this week, read the last 4 weekly grant-scout Drive memos to know:
 
-- **What's already in the pipeline** — open `funding:prospect`, `funding:drafting`, `funding:submitted` Issues across the Linear Product team. Query Linear at run start by label (`funding:*`) and team (Product), not by project — the routing surface is the saved view over labels, not a single container.
+- **What's already in the pipeline** — open `funding:prospect`, `funding:drafting`, `funding:submitted` Issues. **Query Linear at run start by `funding:*` label across the whole workspace — do NOT scope to one team.** Non-awarded grants live in the Research team's `Grant Scouting` project and awards live in Product, so a team-scoped query silently misses half the pipeline — this is exactly what re-surfaces already-tracked programs as "NEW".
 - **What's already in stewardship** — open `funding:active-award` Issues and any bounded award/delivery projects. Refresh stewardship status; never re-surface a won grant as a new prospect.
 - **What was already evaluated and dismissed** — programs prior memos marked `dismiss` with rationale. Do not re-surface unless there's clear new context.
 - **Stale prospects** — any `funding:prospect` open >30 days without movement. Surface in Phase 5 for triage or auto-dismissal.
@@ -85,7 +94,7 @@ The output of Phase 0 is the sets carried into Phase 1 and Phase 4:
 
 ## Phase 1: Discovery (active, not retrospective)
 
-The point of this routine is to surface opportunities the team has not seen. Each substep below feeds candidates into a single deduplicated set. **Surface every candidate that clears the Phase 2 fit bar — do not stop at a quota.** The run succeeds with **≥ 3 NEW** candidates (not in `KNOWN_PROGRAMS`), but 3 is a floor, not a target: aim for **6–8 NEW** across the rotating clusters, and only stop when you've genuinely worked the week's clusters (Phase 1.6) — never because you hit a number.
+The point of this routine is to surface opportunities the team has not seen. Each substep below feeds candidates into a single deduplicated set. **The target is breadth of *scanning*, not a count of opportunities: work 6–8 funders/clusters thoroughly each run (Phase 1.6), then surface only those that pass BOTH the Phase 2 fit bar and the Phase 2 existence-verification gate.** Surfacing 1–2 genuinely-new, verified opportunities is a successful week; some weeks legitimately yield zero, and that is fine. **Never invent, pad, re-frame, or re-surface a known/closed program to hit a number — a fabricated or unverified "opportunity" is a worse outcome than a quiet week: it wastes the team's time and risks our credibility with funders.**
 
 ### 1.1 — In-channel scan
 
@@ -159,10 +168,19 @@ Read-only — never modify Canva designs.
 - Compare every candidate against `KNOWN_PROGRAMS` from Phase 0. Mark as `NEW` only if not already represented.
 - **Record cadence for everything you touch** — even programs that just closed or open next quarter. Feed `{program, cadence, last/next deadline, fit}` into the Phase 0 `PROGRAM_CYCLES` calendar, and add strong-fit near-misses reopening within ~8 weeks to `REOPEN_WATCH`. A recorded near-miss is a future win; a forgotten one is recurring regret.
 - If you spend < 30 minutes on Phase 1.6 in a run, the routine is failing its core job — extend coverage.
-- **Cover all three primary targets every run.** The pipeline has historically over-indexed Green Goods while Coop and PGSP stay thin — do not let GG candidates fill the run's quota and crowd out the others. Each run, scan at least one funder for Coop's stack (Filecoin ProPGF / devgrants, Safe grants) and one for PGSP's stack (Lido CSM / LEGO, SSV / DVT, Obol, plus the broader restaking/staking grant surface — EigenLayer ecosystem, Rocket Pool GMC), and actually hit the decentralized-identity surface named in Cluster D (DIF, OpenWallet, Trust-over-IP) — the shared passkey/identity primitive spans GG + Coop and is the most under-scouted lane.
+- **Cover all three primary targets every run.** The pipeline has historically over-indexed Green Goods while Coop and PGSP stay thin — do not let GG candidates fill the run's quota and crowd out the others. Each run, scan at least one funder for Coop's stack (Filecoin ProPGF / devgrants, Safe grants) and one for PGSP's stack (Lido CSM / LEGO, SSV / DVT, Obol, plus the broader restaking/staking grant surface — EigenLayer ecosystem, Rocket Pool GMC), and actually hit the decentralized-identity surface named in Cluster D (DIF, OpenWallet, Trust-over-IP) — the shared passkey/identity primitive spans GG + Coop and is the most under-scouted lane. Scanning a lane is a search instruction, not a mandate to return a hit: if the identity/passkey funders have nothing open that fits, that lane is simply empty this week (record it) — never manufacture a fit (e.g. a non-existent "passkey RFP") to fill it.
 - If a cluster returns zero, record the exact queries/URLs that came back empty in the Phase 6 memo so the next run fixes the query rather than re-running a dead one.
 
 ## Phase 2: Fit Assessment
+
+**Existence verification — gate every candidate before it is scored, surfaced in Discord, written to a Linear Issue, or named in the memo. The gate rejects the *disproven*, not the merely *unconfirmed*.** Every candidate must have a **funder-controlled URL** (the funder's own site — not an aggregator). Classify each:
+
+- **Confirmed** — you fetched the funder page this run and it names the program AND the program is open, **rolling / always-open**, or states a concrete next cycle. Surface normally; record the fetched URL as the canonical link.
+- **Disproven** — you fetched the funder's page or index and it does **not** name the program, contradicts it, or shows it permanently closed. **Reject — do not surface.** This is the fabrication case (e.g. inventing an "EF passkey-support RFP" the ESP page never lists). Note it in the memo as "could not substantiate" so it isn't rediscovered.
+- **Couldn't auto-verify** — you have a plausible funder URL but the fetch failed (403 / paywall / JS-only / timeout) or the page didn't state its open status. Surface it, but **tag it `⚠️ unverified — human confirm` and keep the funder URL** so a human can check. Many of the guild's strongest funders (climate / Africa / government portals, and rolling programs) routinely block bots — a failed fetch is **not** disproof, so never demote these to nothing.
+- **No funder URL at all** — only an aggregator mention or a search hit you couldn't trace to a funder page. List under "🔍 Unverified leads" (Phase 5) with the query — no fit score, no Linear Issue.
+
+**Do not synthesize an opportunity by fusing a funder you know with a topic, RFP, or program name you assume** — a specific call/RFP exists only if a funder page says so in those words. Re-surfacing a program already in `KNOWN_PROGRAMS` (including closed/dismissed ones) as "NEW" is a verification failure: comment on its Issue, don't open a new opportunity line.
 
 **Optional PostHog evidence enrichment** (subtle, secondary): when a candidate's fit clearly depends on production-traction signals (Green Goods grants that ask "show user growth" or "show retention"), pull a single headline metric from PostHog using a curated question name from `green-goods/.claude/skills/posthog-questions/SKILL.md`. Privacy mode: public. Use this to inform fit scores and Phase 3 evidence — never paste raw HogQL or private fields into the assessment. If PostHog is unreachable, skip the enrichment and continue with the assessment based on existing evidence.
 
@@ -249,23 +267,23 @@ Never submit proposals. Human review owns final submission.
 
 ## Phase 4: Linear funding-lifecycle Issues
 
-For any high-fit opportunity, create or update one Linear Issue using the canonical `funding:*` lifecycle. Prospects and in-flight drafts are surfaced through saved views over Product team labels. Awarded grants graduate into a bounded award/delivery project when there is delivery, reporting, compliance, or funder follow-through to manage.
+For any high-fit opportunity **that passed the Phase 2 existence gate** (Confirmed, or Couldn't-auto-verify — flag the latter `⚠️ unverified` in "Human decision needed"), create or update one Linear Issue using the canonical `funding:*` lifecycle. New prospects / drafts / submissions are created in the **Research team's `Grant Scouting` project**. Awarded grants graduate to the **Product team** into a bounded award/delivery project when there is delivery, reporting, compliance, or funder follow-through to manage.
 
 ### Resolve IDs at run start (never hardcode)
 
-- Team: `Product`
+- Team / project: create non-awarded grant Issues in the **Research** team, **`Grant Scouting`** project (awards graduate to **Product**). Resolve team / project / label IDs by name via the Linear connector (e.g. `list_teams` / `list_projects` / `list_issue_labels`) — never hardcode. Create and comment via the connector's issue / comment tools.
 - Labels: resolve all of `funding:prospect`, `funding:drafting`, `funding:submitted`, `funding:active-award`, `agent:routine`, `activity:research`, plus the relevant `protocol:*` (`protocol:green-goods`, `protocol:coop`, `protocol:pgsp`, `protocol:greenwill`, `protocol:network`, `protocol:tas`) by name. Cookie Jar work routes to `protocol:green-goods` (Cookie Jar project is completed; new vault/crowdfunding/funding-pool work lives under Green Goods seasons). Old `area:research` / `work:research` / `automation:routine` labels are retired — do not apply them.
-- Award/delivery projects: resolve any existing bounded award or delivery project by name when transitioning a submission to `funding:active-award` (Phase 4 lifecycle transitions). Do **not** route new prospects into umbrella, staging, or completed projects.
+- Award/delivery projects: when transitioning a submission to `funding:active-award`, resolve the bounded award/delivery project (in Product) by name. Do **not** route new prospects into umbrella, staging, or completed projects — non-awarded grants belong in the Research `Grant Scouting` project.
 
 ### Dedupe first
 
-Query open Issues in the Product team filtered by `funding:*` labels. Match by program name + URL. If a duplicate exists, **comment on the existing Issue** with new context (refreshed deadline, new evidence, updated fit score) — do not create a parallel Issue.
+Query open Issues **across the workspace** filtered by `funding:*` labels (not one team — awards live in Product, everything else in the Research `Grant Scouting` project), and check against `KNOWN_PROGRAMS` from Phase 0. Match primarily on the **funder URL (host + program path)**, secondarily on program name — a re-worded title (e.g. one that adds a topic like "passkey-support") is the **same** program if the funder URL matches. If a duplicate exists, **comment on the existing Issue** with new context (refreshed deadline, new evidence, updated fit score) — never create a parallel Issue.
 
 ### Create new prospect
 
 Title: `Grant: {Program Name}`
 
-Project: leave unprojected unless a bounded award/delivery project already exists and the Issue is `funding:active-award`.
+Project: **`Grant Scouting`** (Research team). Only `funding:active-award` Issues move to a bounded award/delivery project in Product.
 
 Labels: `funding:prospect`, `activity:research`, `agent:routine`, plus the relevant `protocol:*` for primary fit.
 
@@ -332,31 +350,45 @@ For each program in `REOPEN_WATCH` (Phase 0) whose next cycle opens within ~8 we
 ```
 {if mention_required: "<@${DISCORD_USER_ID_AFO}> "}**Guild Grant Scout — Week of {YYYY-MM-DD}**
 
-🆕 **New opportunities this run** ({N})
-• {Program} — deadline {date}, fit: {project(s)}, score: {N}/5 → <Linear URL>
-• ...
+🆕 **New opportunities this run** ({N}) — highest-fit first
+1. **{Program}** — {project(s)} {score}/5 · deadline {date}
+{public grant/program URL — bare, so it previews}
+2. **{Program}** — {project(s)} {score}/5 · deadline {date}
+{public grant/program URL — bare, so it previews}
+…
+
+🔍 **Unverified leads** (no funder URL to point to — human to check / discard)
+• {lead} — {what suggested it} — {query/URL tried}
 
 🔄 **Pipeline movement**
 • {Program}: prospect → drafting (draft saved <Drive URL>)
 • {Program}: drafting → submitted ({date})
 
 ⏰ **Stale prospects** (open > 30d without movement)
-• {Program} — opened {date}, last touched {date} → <Linear URL>  [recommend: dismiss / nudge / draft]
+• {Program} — opened {date}, last touched {date}  [recommend: dismiss / nudge / draft]
 
 📅 **Upcoming deadlines (next 14 days)**
 • {Program} — {date}
 
 ⏭️ **Opening soon / reopen watch** (pre-staged from `REOPEN_WATCH`)
-• {Program} — reopens ~{date}, fit: {project} → <Linear URL>
+• {Program} — reopens ~{date}, fit: {project}
 
-📊 **Pipeline snapshot**
+📊 **Pipeline snapshot** (from this run's live Linear read)
 • Prospect: {N} · Drafting: {M} · Submitted: {K} · Active award: {R}
+
+🔗 **Linear tracking:** {Program} <Linear URL> · {Program} <Linear URL> · …
 
 📈 **Coverage this run**
 • Sources: Discord {D} · Drive {V} · Web search {W} · Calendar {C} · Miro {B} · Canva {N}
 • Clusters worked this run (Phase 1.6): {which of A–E got deep coverage}
 • Web queries that returned empty: {short list — informs next-week strategy tuning}
 ```
+
+**Link formatting (Discord shows a rich preview for at most ~5 bare URLs per message — spend those slots on the grants):**
+- Put each new opportunity's **public grant/program URL bare** (no `<>`, not a masked `[text](url)` link) on its own line, **ordered highest-fit first**, so the top ≤5 grants get previews. For opportunities beyond the 5th, include the grant URL wrapped in `<>` to avoid a stack of preview-less cards.
+- Put **Linear issue links in the grouped `🔗 Linear tracking` line, each wrapped in `<>`** so they neither consume preview slots nor render broken "access required" cards (the workspace is private).
+- Every entry under "New opportunities" carries a real grant URL (guaranteed by the Phase 2 existence gate). If a line has no clickable funder URL, it belongs under "🔍 Unverified leads", not here.
+- An opportunity tagged `⚠️ unverified` (Phase 2 couldn't-auto-verify — e.g. the funder portal 403'd or is rolling with no "open" banner) stays in "New opportunities" with its ⚠️ tag and funder URL — it's a real funder for a human to confirm, not an "Unverified lead".
 
 ### Quiet week (zero new opportunities AND zero pipeline movement)
 
@@ -390,6 +422,7 @@ After posting to #funding, save a memo titled `YYYY-MM-DD grant scout` (title co
 *Generated by `guild-grant-scout`. Drives prior-run continuity for future runs of this routine — keep concise but complete.*
 
 ## Coverage
+- Preflight / surface health: {Linear ok? which secondary surfaces were reachable vs down}
 - Discord #funding messages reviewed: {N}
 - Drive docs considered: {V}
 - Web searches run: {list with result counts}
@@ -400,7 +433,10 @@ After posting to #funding, save a memo titled `YYYY-MM-DD grant scout` (title co
 {Bullets: which ecosystems / aggregators / search queries got attention. Note which returned empty.}
 
 ## New opportunities surfaced
-{Per-opportunity: name, URL, deadline, fit score, Linear Issue URL}
+{Per-opportunity: name, fetched funder URL, deadline, fit score, Linear Issue URL}
+
+## Unverified leads (not surfaced)
+{Candidates that failed the Phase 2 existence gate: lead, what suggested it, query/URL tried — so a future run or a human can confirm or discard rather than re-discovering.}
 
 ## Pipeline movements
 {prospect→drafting, drafting→submitted, awarded, rejected, cancelled}
@@ -431,15 +467,17 @@ If the Drive write fails, still consider the run successful (Discord post + Line
 
 ## Guardrails
 
-- **This is a non-interactive scheduled routine — never ask the user anything.** No human reads your output at runtime. Never call `AskUserQuestion`, present options, pause for confirmation, or end a run on a question. Every branch must terminate in a concrete action (a Drive write, a Discord post, a Linear create/update) or a clean logged exit. In any ambiguous or undefined state, take the **lowest-blast-radius** action — almost always "touch no shared surface, log the reasoning to the Phase 6 memo, and exit" — never defer to a human who is not there. The only human touchpoints are asynchronous and written: the "Human decision needed" field in a Linear Issue and the `<@${DISCORD_USER_ID_AFO}>` mention in the weekly heartbeat. Those are artifacts a human reads later, not interactive prompts that block the run.
-- **Active discovery is the job.** ≥ 3 NEW (not-in-`KNOWN_PROGRAMS`) candidates is the floor, **6–8 the target** — never satisfice at 3. Rotate the Phase 1.6 clusters so a month of runs covers the whole funder universe (web3, climate, Africa/dev, OSS-infra). Discord/Drive/Calendar reads are signal-feeds, not the discovery surface.
-- **Linear `funding:*` lifecycle is the canonical surface.** Prospects/drafts/submissions are surfaced through saved views over Product team labels; awarded grants graduate into bounded award/delivery projects when needed. Do not write grant lifecycle Issues anywhere else — not `.github` (no GitHub Issues, ever), not project repos, and not umbrella, staging, or completed Linear projects.
+- **This is a non-interactive scheduled routine — never ask the user anything.** No human reads your output at runtime. Never call `AskUserQuestion`, present options, pause for confirmation, or end a run on a question. Every branch must terminate in a concrete action (a Drive write, a Discord post, a Linear create/update) or a clean logged exit. In any ambiguous or undefined state, take the **lowest-blast-radius** action — almost always "touch no shared surface, log the reasoning to the Phase 6 memo, and exit" — never defer to a human who is not there. The only human touchpoints are asynchronous and written: the "Human decision needed" field in a Linear Issue and the `<@${DISCORD_USER_ID_AFO}>` mention in the weekly heartbeat. Those are artifacts a human reads later, not interactive prompts that block the run. **If a *required* surface (Linear) is unavailable, this same principle is mandatory — do not scout: post the one-line status to `#funding`, write the memo, and exit (Phase 0 fail-closed). A silent skip is the correct lowest-blast-radius action; a degraded run that emits opportunities is not.**
+- **Active discovery is the job — but the target is breadth of scanning, not an opportunity quota.** Work 6–8 funders/clusters thoroughly each run and rotate them so a month covers the whole funder universe (web3, climate, Africa/dev, OSS-infra). Surface only what passes the Phase 2 existence gate; 1–2 verified opportunities — or zero on a genuinely dry week — is a success. **Never pad, invent, re-frame, or re-surface a known/closed program to hit a number.** Discord/Drive/Calendar reads are signal-feeds, not the discovery surface.
+- **Linear `funding:*` lifecycle is the canonical surface, reached via the Linear connector.** Non-awarded grants live in the Research `Grant Scouting` project; awards graduate to Product. **Read `funding:*` workspace-wide, never one team.** Do not write grant lifecycle Issues anywhere else — not `.github` (no GitHub Issues, ever), not project repos, and not umbrella, staging, or completed Linear projects.
 - **Post the weekly heartbeat exactly once per cycle** to `#funding`. The first run of the cycle must post (silent first-runs are not allowed); a subsequent same-cycle manual re-trigger must suppress the duplicate (see the Phase 0 same-cycle guard).
 - **Always write the Phase 6 memo.** It is the substrate that lets Phase 0 work — skipping it breaks future continuity.
 - **Populate the cycle calendar every run.** `PROGRAM_CYCLES` / `REOPEN_WATCH` (Phase 0) must capture recurring funders even when currently closed (e.g. UNICEF Venture Fund ~annual, Gitcoin GG rounds, GSMA / EEP / AECF cohorts, Shuttleworth's Nov/Mar intakes). A closed window recorded with its reopen date is a future win; an unrecorded one is the routine rediscovering a program a cycle too late — the single most common way this routine loses value.
 - **One full draft per run max.** Lightweight outlines for additional urgent opportunities are fine.
 - **Never submit proposals.** Human review owns final submission.
 - **Only claim capabilities that exist in the code today.** Planned work must be labeled as proposed.
+- **Every opportunity must exist — reject the disproven, flag the merely unconfirmed.** Never surface a program you **disproved** (fetched the funder page and it doesn't name it) or **fabricated** by fusing a funder with an assumed topic/RFP. A real funder whose page you simply couldn't fetch (403 / paywall / rolling with no "open" banner) is surfaced **tagged `⚠️ unverified — human confirm`** with its URL — not invented, not silently dropped. Aggregator-only hits with no funder URL go under "Unverified leads". (Phase 2 existence gate.)
+- **Verify factual claims against primary sources before they enter a draft, Issue, or post.** Track record, prior funding, partnerships, "live" capabilities, and metrics must each trace to a primary source — the grants ledger for funding status, the indexer/PostHog for metrics, repo code for capabilities. If a claim can't be verified, omit it or mark "unverified — confirm before submission". Never upgrade "applied"/"in progress" to "awarded"/"completed". A fabricated track-record claim is a credibility risk with funders and a disqualifier with several (incl. NLnet).
 - **Don't share sensitive metrics, unannounced strategy, private counterparties, or budget details in Discord.** Those go to Drive + Linear.
 - **Do not modify source files in any project repo or edit Miro boards or Canva designs.** All design-surface reads are read-only.
 - **PostHog is privacy-public mode only.** Never paste replay URLs, session IDs, distinct IDs, wallet addresses, or any private field. Curated question names only — no raw HogQL in the routine reasoning.


### PR DESCRIPTION
## Why
The 2026-05-28 run failed two ways: **"Linear unreachable"** (again) and a **fabricated opportunity** — "EF ESP passkey-support RFP", a real-but-archived program (RESR-37) re-surfaced as NEW with an invented RFP framing. Root-caused to this spec. Five root causes → eight coordinated fixes (one file: `routines/claude/guild-grant-scout.md`).

## What changed

**Linear — connector stays the path, no API key stored**
- Linear reads/writes stay on the **Linear connector**. The recurring failure (the OAuth connector lapsing between unattended runs) is handled by **failing closed**, not by a stored key: a run-start preflight checks the connector, and if it's unauthed/unreachable the routine posts one line — "Linear connector unavailable (needs re-authorization)" — and exits. It never scouts without dedup (scouting blind is what re-surfaced archived programs as NEW).

**Correct Linear routing (independent of connectivity)**
- Reads are **workspace-wide by `funding:*` label** (was: Product team only). The pipeline moved to **Research / `Grant Scouting`** on 2026-05-30 and awards live in Product, so the old single-team query silently missed half the pipeline.
- New prospects/drafts are created in **Research / Grant Scouting**; awards graduate to **Product**. Dedup is keyed on **funder URL**, not just title (a reworded title is the same grant).

**Anti-fabrication**
- **Phase 2 existence gate** — *Confirmed* → surface; *Disproven* → reject (the EF-ESP case); *Couldn't-fetch (403 / paywall / rolling)* → surface tagged `⚠️ unverified — human confirm` (so bot-blocked climate / Africa / gov portals aren't punished); *no URL* → "Unverified leads". Rolling / always-open counts as open.
- **Quota reframed**: 6–8 is breadth of *scanning*, not an opportunity count. A quiet week beats a fabricated one.
- **Folds in #19**: removes the "Evidence Commons" false-prior-grant claim + the hardcoded "13 live gardens"; adds a verify-claims-vs-primary-source guardrail.

**Output**
- Discord posts carry **bare grant URLs** (rich previews, top ≤5 by fit) and group **Linear links `<>`-suppressed** (private workspace, no previews). Adds a 🔍 Unverified-leads section and a run-start health line in the memo.

## Notes for merge
- **Supersedes #19** — close it (same lines).
- **No env / secret changes.** If the Linear connector lapses, re-authorize it; the routine now flags that and skips rather than fabricating.

The thin-wrapper trigger re-reads this file each run, so it ships on merge with no trigger reconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
