### PR TITLE
fix(routines): give software-ecology-pulse the Discord REST recipe + …

### DIFF
--- a/routines/claude/software-ecology-pulse.md
+++ b/routines/claude/software-ecology-pulse.md
@@ -185,7 +185,32 @@ No automatic work created.
    - Health: selected rubric value
    - Body: status update Markdown
 2. Write a Drive memo titled `Software Ecology Pulse - YYYY-WW` in the Dev Guild shared Drive context.
-3. Post the short Discord summary to `DISCORD_LEAD_COUNCIL_CHANNEL_ID`.
+3. Post the short Discord summary to the private lead-council channel.
+
+   **There is NO Discord MCP/connector in this environment — post via the Discord REST
+   API with Bash + `curl`. Do NOT search for a Discord tool/connector, and do NOT
+   degrade to "prepared but not posted": an unsent summary is a degraded-run failure
+   line, not a silent no-op.** `DISCORD_BOT_TOKEN` and `DISCORD_LEAD_COUNCIL_CHANNEL_ID`
+   are in the environment.
+
+   **Channel guard:** the only allowed POST target is `${DISCORD_LEAD_COUNCIL_CHANNEL_ID}`.
+   If it is unset or invalid, log `discord: channel unset`, skip the post, and surface it
+   in the run report — never substitute another channel.
+
+   Build the payload with `jq` (or `python3` — never raw string interpolation; the body
+   has newlines and backticks), POST it, and check the HTTP status:
+
+   ```bash
+   jq -nc --arg c "$SUMMARY" '{content:$c}' \
+     | curl -sS -w '\n%{http_code}' -X POST \
+         "https://discord.com/api/v10/channels/${DISCORD_LEAD_COUNCIL_CHANNEL_ID}/messages" \
+         -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+         -H "Content-Type: application/json" --data-binary @-
+   ```
+
+   A 2xx with a returned message id means posted. Any other status (or `channel unset`)
+   is a degraded-run line in the report — never a silent skip. The summary is well under
+   Discord's 2000-char limit, so no chunking is needed.
 
 After writing, report only:
 


### PR DESCRIPTION
…channel guard

<!--
Thanks for the contribution! Please fill this in so reviewers can move quickly.
For project-specific PR conventions, check the project's own CONTRIBUTING.md.
-->

## Summary

<!-- What does this PR do? One or two sentences. -->

## Why

<!-- The motivation. Link to the issue, RFC, Linear reference, or funded-work scope. -->

Closes # <!-- issue number, Linear/funded-work reference, or "n/a" -->

## What changed

<!-- Bullet list of notable changes. Group by package or area if helpful. -->

-

## Test plan

<!-- How did you verify this works? -->

- [ ]
- [ ]

## Risk and rollout

- **Risk level**: <!-- low / medium / high — touches deploy/contracts/auth/CI? -->
- **Rollout**: <!-- merge as-is / behind feature flag / staged rollout / requires migration -->
- **Backwards compatibility**: <!-- breaking? deprecation needed? -->

## Checklist

- [ ] CI is green (format, lint, tests, build)
- [ ] Conventional Commit message
- [ ] Tests added or updated for new behavior
- [ ] Docs updated if behavior changed
- [ ] Open-source-only dependencies
- [ ] No secrets, credentials, or `.env*` files committed
- [ ] If touching a high-risk path (deploy, contracts, auth, CI, security), I have requested a steward review

## Notes for reviewer

<!-- Anything else worth flagging — known limitations, follow-ups, design tradeoffs. -->
