### PR TITLE
refactor(routines): software-ecology-pulse computes its snapshot in-cloud; V1 set = the 3 guild repos

### DIFF
--- a/docs/software-ecology.md
+++ b/docs/software-ecology.md
@@ -8,8 +8,8 @@ This is not a backlog. It is an operating map for seeing whether AI-assisted dev
 
 | Surface | Owns | Does not own |
 | --- | --- | --- |
-| `dev-surfaces` | Local executable snapshot: `dev ecology --json`, Drive-ready handoff bundle via `dev ecology --json --handoff`, live dev-surface status, git state, plan counts, validation scripts, and ignored local snapshots | Durable guild policy, hosted routine setup, Linear status |
-| `.github` | Guild-level policy, routine source prompts, source-of-truth split, and shared language | Local process ownership or repo runtime launch details |
+| `dev-surfaces` | Local executable snapshot: `dev ecology --json`, local handoff bundle via `dev ecology --json --handoff`, live dev-surface status, git state, plan counts, validation scripts, and ignored local snapshots | Durable guild policy, hosted routine setup, hosted routine input, Linear status |
+| `.github` | Guild-level policy, routine source prompts, the pulse registry metadata below, source-of-truth split, and shared language | Local process ownership or repo runtime launch details |
 | Project `.plans` | Execution truth for active feature work and lane state | Cross-repo status, social priority, or release authority |
 | Linear | Roadmap/status tracking, initiatives, accepted work, and status updates | Repo implementation truth or code review |
 | Drive | Weekly memos and evidence archive | Work ownership or implementation state |
@@ -17,30 +17,51 @@ This is not a backlog. It is an operating map for seeing whether AI-assisted dev
 
 ## V1 repo set
 
-The first ecology index covers:
+The ecology index covers the three guild-org repos:
 
-| Repo | Tier | Role |
-| --- | --- | --- |
-| Green Goods | Tier 1 heavy agentic product | Reference implementation for heavy `.plans`, shared contracts, design/docs drift checks, browser proof, and release complexity |
-| Coop | Tier 1 heavy agentic product | Reference implementation for human attention, agent policy, local-first review, and validation selection |
-| Greenpill Network | Tier 1 heavy agentic product | Reference implementation for public/private route contracts and workspace/auth decision discipline |
-| WEFA | Tier 1 heavy agentic product | Reference implementation for child-safety, route-local validation, and child-facing browser proof |
-| Portfolio | Tier 2 lightweight public site | Lightweight route, contact validation, Storybook, and browser-proof surface |
-| TAS-Hub | Tier 2 lightweight public site | Lightweight public Next.js site with token, smoke, and motion/accessibility guardrails |
+| Repo | Tier | Role | Source-truth globs |
+| --- | --- | --- | --- |
+| Green Goods | Tier 1 heavy agentic product | Reference implementation for heavy `.plans`, shared contracts, design/docs drift checks, browser proof, and release complexity | `.plans/active/*/status.json`, `.plans/backlog/*/status.json`, `AGENTS.md`, `CLAUDE.md`, `package.json` |
+| Coop | Tier 1 heavy agentic product | Reference implementation for human attention, agent policy, local-first review, and validation selection | `.plans/features/*/status.json`, `AGENTS.md`, `CLAUDE.md`, `package.json` |
+| Greenpill Network | Tier 1 heavy agentic product | Reference implementation for public/private route contracts and workspace/auth decision discipline | `.plans/active/*/status.json`, `.plans/backlog/*/status.json`, `AGENTS.md`, `CLAUDE.md`, `package.json` |
 
-Impact Reef and other dormant repos stay out of V1 until they become active work again.
+Portfolio, WEFA, and TAS-Hub left the guild V1 set in 2026-W24 (personal or guild-adjacent repos owned outside the guild org); they remain in the local dev-surfaces registry for local workflows only. Impact Reef and other dormant repos stay out of V1 until they become active work again.
+
+### Pulse registry metadata
+
+Curated judgment fields consumed by the weekly pulse. A local twin lives in the dev-surfaces registry for local workflows; the pulse reads only this section.
+
+**Green Goods**
+
+- API/privacy boundaries: Shared hooks, domain types, and public contracts live in `packages/shared`. Agent and webhook behavior lives in `packages/agent`. Contract deployment artifacts remain the address source of truth.
+- Release/rollback: Use repo-specific build, docs, design, package, browser-proof, and deploy scripts. Onchain or deploy rollback must be treated as a human-reviewed operation.
+- Likely bottleneck: Source-structure debt, dirty-tree coordination, and choosing the right validation depth before adding more concurrent agent work.
+
+**Coop**
+
+- API/privacy boundaries: Durable domain logic lives behind `@coop/shared` and `@coop/shared/app`. Review and publish remain explicit human decisions. Local-first extension state, sync, session, policy, and signing surfaces are high-risk.
+- Release/rollback: Use `validate:production-readiness` for mock-first readiness and `validate:production-live-readiness` only when live rails are intentionally in scope.
+- Likely bottleneck: Selecting the smallest sufficient validation suite across many agent, sync, policy, archive, and UI surfaces.
+
+**Greenpill Network**
+
+- API/privacy boundaries: Public website remains static and public-safe. Private runtime, database, and intake concerns stay behind `packages/agent`. Public agent routes need exported constants, shared contracts, public-safe normalization, and tests.
+- Release/rollback: Public site currently builds from `packages/website`; agent deploys use `packages/agent/fly.toml`. Workspace/auth runtime remains decision-packed before implementation.
+- Likely bottleneck: Workspace/auth boundary decisions and integration proof across website snapshot, agent route, shared contract, Directus, and Postgres.
 
 ## Signal definitions
 
-`dev ecology --json` is the machine-readable inspection snapshot. `dev ecology --json --handoff` is the hosted routine input. Both should be treated as point-in-time local snapshots, not as replacements for project repo truth.
+`dev ecology --json` is the local machine-readable inspection snapshot; `dev ecology --json --handoff` bundles it with a Markdown sibling for human review. Both are local conveniences: the hosted routine computes its own snapshot from cloud clones and does not consume these files. Treat them as point-in-time local snapshots, not as replacements for project repo truth.
 
-The snapshot records:
+The local snapshot records:
 
 - Git branch, upstream, ahead/behind, dirty count, and change-type counts.
 - Plan-hub `status.json` count and canonical lane status totals, when `.plans` exists. Raw lane vocabularies remain in JSON for audit.
 - Validation, browser-proof, release, deploy, and agentic scripts from `package.json`.
 - Workbench dev-surface status for repos registered in `dev-surfaces`.
 - Curated risk tier, source-truth surfaces, API/privacy boundaries, release/rollback notes, and likely bottleneck.
+
+The hosted pulse computes a narrower, clone-derivable subset: plan-lane counts, guidance presence, root script inventory, last-commit recency, and main-develop drift. Working-tree state and dev-surface runtime are local-only signals and never appear in the pulse.
 
 Healthy ecology signals:
 
@@ -60,15 +81,7 @@ At-risk ecology signals:
 
 ## Weekly pulse
 
-The `software-ecology-pulse` routine is status-only.
-
-Before enabling or running the hosted routine, produce the weekly handoff locally:
-
-```sh
-dev ecology --json --handoff
-```
-
-Upload or attach the generated JSON as `Software Ecology Snapshot YYYY-WW`. The Markdown sibling is for human review. This makes the routine deterministic: Claude reads the handoff snapshot and allow-listed guidance surfaces; it does not run local commands, start browsers, or infer local repo state from memory.
+The `software-ecology-pulse` routine is status-only and self-sufficient: each run computes its ecology snapshot from the fresh cloud clones of the three V1 repos (plan-lane counts, guidance presence, root script inventory, git recency, and main-develop drift where refs allow) plus the pulse registry metadata in this document. No local snapshot generation, upload, or attachment is required, and the routine must not search Drive for one.
 
 Allowed outputs:
 
@@ -85,11 +98,11 @@ Forbidden outputs:
 - No secret reads.
 - No heavy validation runs.
 
-If the local ecology handoff is missing, incomplete, or stale, the routine must mark health `atRisk`, explain which proof is missing, and avoid creating work.
+If a V1 clone is missing or unreadable, the routine marks health `atRisk`, names the missing repo, and creates no work.
 
 ## Reading the dashboard
 
-Use `dev ecology --markdown` for human review, `dev ecology --json` for machine inspection, and `dev ecology --json --handoff` for the weekly routine input.
+Use `dev ecology --markdown` for human review and `dev ecology --json` for local machine inspection.
 
 Read the output in this order:
 

--- a/routines/claude/README.md
+++ b/routines/claude/README.md
@@ -14,9 +14,9 @@ Distinct from `../*.md` markdown playbooks for manual guild processes like funde
 | `guild-grant-scout.md` | active | Wed 19:00 weekly | `#funding` + Drive memo | Linear Product (unprojected staging, `funding:*` lifecycle); accepted awards route into a dedicated `Grant Proposal / Award Stewardship` project |
 | `research-synthesis.md` | active | Fri 17:00 weekly | `#research` + Drive memo | Linear Research team (unprojected, `activity:research`) |
 | `research-accountability-pulse.md` | active | Mon & Thu 08:00 twice-weekly | `#research` + Linear comments | Flags Research team slippage (past-due / stalled / due-soon); comments + `@`-mentions the owner on each flagged issue (idempotent, ~weekly per issue) |
-| `software-ecology-pulse.md` | source-ready | Mon 19:30 weekly | Linear + Drive + private Discord | Initiative status update on `Software Ecology & Agentic Workflow Health`; requires `Software Ecology Snapshot YYYY-WW` handoff; no Issues or Customer Needs |
+| `software-ecology-pulse.md` | active | Mon 19:30 weekly | Linear + Drive + private Discord | Initiative status update on `Software Ecology & Agentic Workflow Health`; computes its ecology snapshot in-run from the three cloned guild V1 repos; no Issues or Customer Needs |
 
-Five weekly runs plus a twice-weekly research-accountability pulse are active, alongside the source-ready software ecology pulse. Monday opens with the cross-project synthesis that primes the week; the ecology pulse is intended to follow after a fresh `dev ecology --json --handoff` snapshot has been uploaded or attached as `Software Ecology Snapshot YYYY-WW`. Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before build sync, then handles grants midweek. Friday closes the week with research synthesis. The read-only research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. No daily-cadence routines.
+Six weekly runs plus a twice-weekly research-accountability pulse are active. Monday opens with the cross-project synthesis that primes the week; the ecology pulse follows at 19:30, computing its own ecology snapshot from its fresh clones (no local handoff). Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before build sync, then handles grants midweek. Friday closes the week with research synthesis. The read-only research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. No daily-cadence routines.
 
 Anything else previously in this folder has been removed — folded into the surviving routines or cut as noise.
 
@@ -31,8 +31,6 @@ The guild routines read these active project repos:
 | green-goods | greenpill-dev-guild |
 | coop | greenpill-dev-guild |
 | network | greenpill-dev-guild |
-| app | wefa-labs |
-| portfolio | Oba-One |
 | cookie-jar | greenpill-dev-guild |
 | TAS-Hub | Greenpill9ja |
 
@@ -45,7 +43,7 @@ Other guild repos (gardens, impact-reef, gg24-round-explorer, octant-v2(-core), 
 ```text
 Mon  08:00  research-accountability-pulse
 Mon  18:00  guild-weekly-synthesis
-Mon  19:30  software-ecology-pulse (source-ready; enable after snapshot handoff is configured)
+Mon  19:30  software-ecology-pulse
 Tue  16:00  network-steward-intent-pulse
 Wed  15:30  coop-intent-pulse
 Wed  19:00  guild-grant-scout
@@ -90,7 +88,7 @@ All active routines use the `guild-routines` environment at claude.ai/code/routi
 - `DISCORD_RESEARCH_CHANNEL_ID`
 - `DISCORD_LEAD_COUNCIL_CHANNEL_ID`
 - `DISCORD_USER_ID_AFO` — Afo's Discord snowflake ID for `<@${DISCORD_USER_ID_AFO}>` mentions
-- `LINEAR_API_KEY` — used by `network-steward-intent-pulse`, `coop-intent-pulse`, and `software-ecology-pulse` (initiative status updates), `guild-grant-scout` (`funding:*` lifecycle saved views), and `research-synthesis` (Research team)
+- `LINEAR_API_KEY` — used by `network-steward-intent-pulse` and `coop-intent-pulse` (initiative status updates), `guild-grant-scout` (`funding:*` lifecycle saved views), and `research-synthesis` (Research team); `software-ecology-pulse` rides the Linear OAuth connector instead
 
 **Connector matrix:**
 
@@ -99,7 +97,7 @@ All active routines use the `guild-routines` environment at claude.ai/code/routi
 | `guild-weekly-synthesis` | Google Drive, Google Calendar, Miro, Figma, Canva, Linear, PostHog, Vercel | Linear = source of truth for cross-project work (initiatives, projects, issues, customer needs) · Drive/Calendar = meeting + scheduling context · Miro/Figma/Canva = design + asset movement · PostHog = link to growth-pulse digest (rare direct fallback) · Vercel = deploy activity counts in per-project bullets (color, never primary) |
 | `network-steward-intent-pulse` | Linear | Linear = social truth for Network steward-hub status; the Network repo checkout provides `.plans` execution truth. No Discord, Drive, GitHub write, PostHog, Vercel, or design connectors. |
 | `coop-intent-pulse` | Linear | Linear = social truth for Coop intent status; the Coop repo checkout provides `.plans` execution truth. No Discord, Drive, GitHub write, PostHog, or design connectors. |
-| `software-ecology-pulse` | Google Drive, Linear | Local `dev ecology --json --handoff` snapshot is the primary input and must be uploaded/attached as `Software Ecology Snapshot YYYY-WW`; Linear = initiative status update only; Drive = memo archive; Discord is posted through the configured bot token. No Issues, Customer Needs, PRs, repo edits, deploys, browser sessions, or heavy validation. |
+| `software-ecology-pulse` | Google Drive, Linear | Ecology truth is computed in-run from the three cloned guild V1 repos plus the pulse registry metadata in `docs/software-ecology.md` (no uploaded snapshot, no host dependency); Linear = initiative status update only (OAuth connector, no API key); Drive = memo archive; Discord is posted through the configured bot token. No Issues, Customer Needs, PRs, repo edits, deploys, browser sessions, or heavy validation. |
 | `guild-grant-scout` | Google Drive, Google Calendar, Miro, Canva, Linear, PostHog | Linear = `funding:*` lifecycle saved views; accepted awards graduate to a bounded award/delivery project · Drive = drafts + reusable evidence · Calendar = deadlines · Miro = planning context · Canva = existing pitch decks to reference/reuse · PostHog = subtle grant-evidence signal (active gardens, action volume) |
 | `research-synthesis` | Google Drive, Linear, Miro, Google Calendar, Canva, PostHog, Mermaid Chart | Drive + Linear = primary signal (Linear Research team, unprojected) · Miro/Calendar/Canva/PostHog = color enrichment (active week only, never on quiet/silent weeks) · Mermaid = generative for diagrams embedded in Linear Issue bodies |
 | `research-accountability-pulse` | Linear | Linear = read Research team issues for slippage + post one accountability comment (`@`-mention owner) per flagged issue; Discord summary via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |

--- a/routines/claude/software-ecology-pulse.md
+++ b/routines/claude/software-ecology-pulse.md
@@ -7,29 +7,25 @@ repos:
   - greenpill-dev-guild/green-goods
   - greenpill-dev-guild/coop
   - greenpill-dev-guild/network
-  - wefa-labs/app
-  - Oba-One/portfolio
-  - Greenpill9ja/TAS-Hub
   - greenpill-dev-guild/.github
 environment: guild-routines
 network-access: full  # Linear API + Drive memo + private Discord post
 env-vars:
   - DISCORD_BOT_TOKEN
   - DISCORD_LEAD_COUNCIL_CHANNEL_ID
-  - LINEAR_API_KEY
 connectors:
   - google-drive
   - linear
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 allow-unrestricted-branch-pushes: false  # Status-only pulse, no Git writes
-status: source-ready
+status: active
 ---
 
 # Prompt
 
 You are the software-ecology pulse routine for the Greenpill Dev Guild. Once a week, check whether the guild's active software ecosystem is staying understandable, validated, and safe for AI-assisted development.
 
-Your job is not to create work. Your job is to synthesize the latest read-only ecology snapshot into three status outputs:
+Your job is not to create work. Your job is to compute a read-only ecology view in-session from the cloned V1 repos and synthesize it into three status outputs:
 
 1. One Linear initiative status update on `Software Ecology & Agentic Workflow Health`.
 2. One Dev Guild shared Drive memo.
@@ -39,42 +35,19 @@ Your job is not to create work. Your job is to synthesize the latest read-only e
 
 This routine reads ONLY:
 
-- The latest `Software Ecology Snapshot YYYY-WW` JSON handoff produced by `/Users/afo/Code/dev-surfaces/bin/dev-surfaces.js ecology --json --handoff`.
+- The fresh git clones of the three V1 repos provisioned for this run (`green-goods`, `coop`, `network`) — the only ecology input; computed in-session, never uploaded, never fetched from Drive.
 - The prior software-ecology Drive memo, if available.
 - The Linear initiative `Software Ecology & Agentic Workflow Health`.
 - Recent status updates on that initiative.
-- These repo guidance and plan surfaces:
-  - `green-goods/AGENTS.md`
-  - `green-goods/CLAUDE.md`
-  - `green-goods/.plans/active/ai-native-dev-workflow/status.json`
-  - `green-goods/.plans/active/ai-native-dev-workflow/artifacts/workflow-scorecard.md`
-  - `green-goods/.plans/active/ai-native-dev-workflow/artifacts/agent-run-ledger.md`
-  - `coop/AGENTS.md`
-  - `coop/CLAUDE.md`
-  - `coop/.plans/features/ai-native-dev-workflow/status.json`
-  - `coop/.plans/features/ai-native-dev-workflow/artifacts/workflow-scorecard.md`
-  - `coop/.plans/features/ai-native-dev-workflow/artifacts/agent-run-ledger.md`
-  - `network/AGENTS.md`
-  - `network/CLAUDE.md`
-  - `network/.plans/active/ai-native-dev-workflow/status.json`
-  - `network/.plans/active/ai-native-dev-workflow/artifacts/workflow-scorecard.md`
-  - `network/.plans/active/ai-native-dev-workflow/artifacts/agent-run-ledger.md`
-  - `app/AGENTS.md`
-  - `app/CLAUDE.md`
-  - `app/.plans/README.md`
-  - `app/.plans/active/ai-native-dev-workflow/status.json`
-  - `app/.plans/active/ai-native-dev-workflow/artifacts/workflow-scorecard.md`
-  - `app/.plans/active/ai-native-dev-workflow/artifacts/agent-run-ledger.md`
-  - `portfolio/AGENTS.md`
-  - `portfolio/.plans/README.md`
-  - `portfolio/.plans/features/modern-css-web-ui-primitives/spec.md`
-  - `TAS-Hub/AGENTS.md`
-  - `TAS-Hub/.plans/README.md`
-  - `TAS-Hub/.plans/features/codex-first-agentic-workflow/spec.md`
-  - `TAS-Hub/.plans/features/modern-css-web-ui-primitives/spec.md`
-  - `.github/docs/software-ecology.md`
+- These repo guidance and plan surfaces (directory-level globs — pack graduation must never break this list):
+  - Per V1 repo: `AGENTS.md`, `CLAUDE.md` (if present), `.plans/README.md`, and the root `package.json`.
+  - `green-goods/.plans/active/*/status.json`, `green-goods/.plans/backlog/*/status.json`, `green-goods/.plans/active/*/artifacts/workflow-scorecard.md`, `green-goods/.plans/active/*/artifacts/agent-run-ledger.md`
+  - `coop/.plans/features/*/status.json`, `coop/.plans/features/*/artifacts/workflow-scorecard.md`, `coop/.plans/features/*/artifacts/agent-run-ledger.md`
+  - `network/.plans/active/*/status.json`, `network/.plans/backlog/*/status.json`, `network/.plans/active/*/artifacts/workflow-scorecard.md`, `network/.plans/active/*/artifacts/agent-run-ledger.md`
+  - `.github/docs/software-ecology.md` (the V1 registry: tiers, source-truth globs, API/privacy boundaries, release/rollback notes, likely bottleneck).
+- Read-only `git` inspection of each clone (`git log`, `git branch -a`, `git rev-parse`, `git rev-list --left-right --count`). When `main` or `develop` refs are missing from a shallow or single-branch clone, at most one `git fetch --no-tags --depth=30 origin main develop` per repo is allowed to make drift measurable. Never `checkout`, never mutate a clone, never fetch anything else.
 
-All six V1 repos are first-class in this routine. If any V1 repo is absent from the handoff snapshot, mark health `atRisk` and explain the missing proof.
+All three V1 repos are first-class in this routine. If any V1 clone is missing or unreadable, mark health `atRisk` and explain the missing proof.
 
 It does NOT read source code, tests, build output, browser artifacts, private databases, secrets, production logs, PostHog, Vercel, Figma, Miro, Calendar, Gmail, GitHub Issues, pull requests, Discord channels beyond the configured output channel, or unrelated `.plans` packs unless a human explicitly expands the scope.
 
@@ -92,18 +65,30 @@ It does NOT read source code, tests, build output, browser artifacts, private da
 - Run no heavy validation suites.
 - Read no secrets or local `.env` files.
 - If the target Linear initiative is missing, fail closed and write nothing to Linear.
-- If Linear is unavailable, still write the Drive memo and Discord summary only if the ecology snapshot is available.
-- If the ecology snapshot is missing or older than 7 days, mark health `atRisk`, explain the missing proof, and create no work.
+- If Linear is unavailable, still write the Drive memo and Discord summary only if the in-session computation covered at least 2 of 3 V1 clones.
+- If any V1 clone is missing or unreadable, mark health `atRisk`, name the missing repo(s), and create no work. If 2 or more clones are missing, mark `offTrack`. Distinguish clone-provision failure (infrastructure) from weak repo signals (ecology) in the explanation.
 - One status update max per ISO week. If a status update already exists for the current ISO week, update that status only when rerunning the same week's pulse.
 
 ## Setup
 
-1. Locate the latest `Software Ecology Snapshot YYYY-WW` JSON handoff. Prefer an attached run artifact or a Drive file with that exact title pattern.
-2. Confirm the snapshot has `version: 1`, a `generatedAt` timestamp, `handoff.isoWeek`, and repos for Green Goods, Coop, Greenpill Network, WEFA, Portfolio, and TAS-Hub.
-3. Treat snapshots older than 7 days as stale.
+1. Locate the V1 clones: `green-goods`, `coop`, `network`, plus the `.github` checkout (policy source, not counted in coverage). Coverage = clones present with readable source-truth surfaces, reported as `N/3`.
+2. Read the V1 registry table and the pulse registry metadata in `.github/docs/software-ecology.md`.
+3. Compute the ecology view in-session (next section). Never reconstruct it from memory, a Drive file, or any uploaded snapshot.
 4. Resolve the Linear initiative by exact name `Software Ecology & Agentic Workflow Health`.
 5. Fetch the latest 4 initiative status updates for continuity.
-6. Read only the allow-listed repo guidance and plan files above.
+6. Read the prior software-ecology Drive memo, if available.
+
+## Compute
+
+Derive per V1 repo, from the clone only:
+
+- **Guidance**: `AGENTS.md` / `CLAUDE.md` present and non-trivial.
+- **Plans**: Glob the repo's source-truth patterns; Read each `status.json`; count packs per lane using the **top-level `status` field only** (status.json files embed nested per-step statuses — ignore them). Bucket: active (`in_progress`, `active`, `ready`) / blocked (`blocked`) / done (`done`, `completed`, `passed`) / queued (`todo`, `pending`, `backlog`, `planned`, `created`, `scaffolded`) / other (report the raw value). Invalid or unparseable JSON is itself a risk signal.
+- **Scripts**: from the root `package.json` only, inventory `agentic:*`, `plans:*`, `validate:*`, `browser-proof*`, `deploy*`, `release*`, and `build` / `check` / `test` / `typecheck`. Workspace packages are intentionally out of scope.
+- **Git**: checked-out branch; last-commit recency (`git log -1 --format=%cI`); when `main` and `develop` refs both exist (after the one allowed bounded fetch if needed), drift via `git rev-list --left-right --count origin/main...origin/develop`. If refs are still unavailable, record the signal as `not measurable this run` — degraded visibility, never a repo failure.
+- **ISO week**: from the run clock, `date -u +%G-W%V` (`%G`, not `%Y` — the ISO year matters at year boundaries). Never reuse a prior week's label.
+
+Not computable in-cloud, by design — never report, estimate, or guess: working-tree dirty counts of anyone's local checkout, local ahead/behind, dev-surface runtime state (ports/PIDs), workbench checks.
 
 ## Analysis frame
 
@@ -119,15 +104,15 @@ Use the software-ecology operating model:
 Look for healthy signals:
 
 - Tier 1 repos have current plan state, explicit validation scripts, and known bottlenecks.
-- Dirty trees are bounded and not confused with completed work.
+- Active lanes correspond to recent commit activity; done is not claimed ahead of merge.
 - Public/private API boundaries are explicit.
 - Browser-proof and integration-proof paths are discoverable.
 - Status updates do not invent new truth surfaces.
 
 Look for at-risk signals:
 
-- Snapshot missing, stale, or incomplete.
-- Tier 1 repo has high dirty count, branch drift, many blocked lanes, or missing proof scripts.
+- V1 clone missing or unreadable, or computation degraded (invalid status.json, refs not measurable).
+- Tier 1 repo has stale last-commit recency, large main-develop drift, many blocked lanes, or missing proof scripts.
 - Release/rollback notes are too vague for the repo's risk level.
 - A repo has agentic activity but no visible human judgment checkpoint.
 - Internal APIs are likely to be called by agents without contract tests.
@@ -136,9 +121,9 @@ Look for at-risk signals:
 
 Use exactly one:
 
-- `onTrack`: snapshot is fresh, Tier 1 risks are bounded, and no immediate cross-repo clarification is needed.
-- `atRisk`: direction is good but stale data, dirty-tree risk, blocked plan lanes, release ambiguity, or validation gaps require human attention.
-- `offTrack`: the routine cannot form a coherent ecology view, the snapshot is absent and repo truth cannot compensate, or active work is likely to diverge without a reset.
+- `onTrack`: all three V1 clones were readable, Tier 1 risks are bounded, and no immediate cross-repo clarification is needed.
+- `atRisk`: direction is good but degraded computation, blocked plan lanes, release ambiguity, or validation gaps require human attention.
+- `offTrack`: the routine cannot form a coherent ecology view, multiple V1 clones are missing and repo truth cannot compensate, or active work is likely to diverge without a reset.
 
 ## Output format
 
@@ -149,7 +134,7 @@ Use this exact Markdown for the Linear status update and the Drive memo summary 
 
 **Health:** `onTrack|atRisk|offTrack`
 
-**Snapshot:** Generated at `TIMESTAMP`; coverage: `N/6` V1 repos.
+**Snapshot:** Computed in-session at `TIMESTAMP` UTC; coverage: `N/3` V1 clones; git visibility: `full|partial`.
 
 **System read:** One short paragraph on whether the ecology is amplifying good practice or adding unmanaged activity.
 
@@ -165,6 +150,8 @@ Use this exact Markdown for the Linear status update and the Drive memo summary 
 
 **No automatic work created:** Confirm that this run created no Issues, Customer Needs, projects, GitHub artifacts, repo edits, deploys, browser sessions, or `.plans` changes.
 ```
+
+Transition note: if the most recent prior status update on the initiative was produced from an uploaded snapshot (any update whose Snapshot line says "Generated at" rather than "Computed in-session"), include one line in the System read: "Metrics rebased: computed in-cloud from clones; not directly comparable to snapshot-era counts." Omit it once prior updates are already in the computed format.
 
 The Discord summary must be shorter:
 


### PR DESCRIPTION
## What

Two layers (structured so the second is revertible while the first survives):

**(a) Scope: V1 set shrinks 6 → 3 — green-goods, coop, network.** Personal/adjacent repos leave the routine: `Oba-One/portfolio`, `wefa-labs/app`, `Greenpill9ja/TAS-Hub`. TAS-Hub keeps its README scope-table row (guild-weekly-synthesis, grant-scout, and the funding sweep still clone it); the wefa and portfolio rows are removed (ecology was their only consumer). Firm decision, no rollback path needed.

**(b) Self-sufficiency: no more host-generated snapshot.** The routine previously required afo to run `dev ecology --json --handoff` on his Mac and upload `Software Ecology Snapshot YYYY-WW` to Drive — stale 2 weeks running. Each run now computes the ecology view in-session from its fresh clones: plan-lane counts (`status.json` top-level `status` only, canonical bucket map), guidance presence, root `package.json` script inventory, last-commit recency, and main-develop drift (one bounded `git fetch --no-tags --depth=30 origin main develop` per repo allowed when refs are missing; never checkout/mutate). Host-only signals (working-tree dirty counts, local ahead/behind, dev-surfaces runtime, workbench checks) are dropped by design. The 7-day staleness guardrail becomes clone-readability: missing clone = `atRisk` + named, 2+ missing = `offTrack`, infrastructure vs ecology distinguished. Registry metadata (API/privacy boundaries, release/rollback notes, likely bottleneck) migrates into `docs/software-ecology.md` as the pulse's cloud-readable registry; dev-surfaces keeps its local twin (consumers now differ, drift stops mattering).

Tidies: allow-list moves to directory-level globs (pack graduation can never break it again), frontmatter model 4-7 → 4-8, `LINEAR_API_KEY` dropped (Linear rides the OAuth connector), `status: source-ready` → `active`. **The Discord REST recipe + channel guard from #26 is preserved byte-identical.**

## Rollback (layer b only)

Restore from the pre-merge sha: the snapshot-input scope line, staleness guardrail, Setup steps 1-3, and the `N/…` Snapshot output line (re-targeted to 3 repos); delete the `## Compute` section; restore the docs `## Weekly pulse` + README snapshot language. dev-surfaces is untouched and its registry still carries all metadata, so the old flow still works. No trigger change needed.

## After merge

The trigger (`trig_01TJFmjFu31Vnyk7MK5H8yKc`) gets a sources/outcomes re-emit dropping portfolio, wefa, and TAS-Hub (7 → 4), then a manual test run; verification via the Linear status update body (coverage `N/3`, "Computed in-session", Discord HTTP + message id in the closing line) and afo eyeballing `#lead-council`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)