### PR TITLE
feat(routines): ecology pulse output gains ranked action items + a fuller Discord read

### DIFF
--- a/routines/claude/software-ecology-pulse.md
+++ b/routines/claude/software-ecology-pulse.md
@@ -146,14 +146,14 @@ Use this exact Markdown for the Linear status update and the Drive memo summary 
 
 **Release/rollback watch:** 1-3 bullets naming gaps or confirming no new gap.
 
-**Action items:** 1-4 ranked recommendations, highest priority first, each derived from the signals above (never invented). Format each as: `[P0|P1|P2]` imperative action or decision, then the repo, then the why / what it unblocks. Ranking: **P0** = a decision or fix needed before more agent work or before a risk compounds; **P1** = worth addressing this cycle; **P2** = minor or cosmetic. List only real items; if nothing is actionable, write `No action items this week.` These are recommendations for humans to act on, not work to file — the create-no-work guardrails still hold (no Issues, no Customer Needs).
+**Action items:** 1-4 ranked recommendations, highest priority first, each derived from the signals above (never invented). Format each as: `[P0|P1|P2]` imperative action or decision, then the repo, then the why / what it unblocks. Ranking: **P0** = a decision or fix needed before more agent work or before a risk compounds; **P1** = worth addressing this cycle; **P2** = minor or cosmetic. List only real items; if nothing is actionable, write `No action items this week.` These are recommendations for humans to act on, not work to file; the create-no-work guardrails still hold (no Issues, no Customer Needs).
 
 **No automatic work created:** Confirm that this run created no Issues, Customer Needs, projects, GitHub artifacts, repo edits, deploys, browser sessions, or `.plans` changes.
 ```
 
 Transition note: if the most recent prior status update on the initiative was produced from an uploaded snapshot (any update whose Snapshot line says "Generated at" rather than "Computed in-session"), include one line in the System read: "Metrics rebased: computed in-cloud from clones; not directly comparable to snapshot-era counts." Omit it once prior updates are already in the computed format.
 
-The Discord summary is a scannable lead-council read — fuller than a teaser, shorter than the full status update. Use this exact shape (normally one message, comfortably under Discord's 2000-char limit; if it ever exceeds 2000, split on a section boundary and POST the chunks sequentially):
+The Discord summary is a scannable lead-council read: fuller than a teaser, shorter than the full status update. Use this exact shape, which fits one message under Discord's 2000-char limit (keep it tight; trim the system read or a bullet before length becomes a problem):
 
 ```md
 **Software Ecology Pulse · YYYY-WW · `health`** · coverage `N/3` · git: `full|partial`

--- a/routines/claude/software-ecology-pulse.md
+++ b/routines/claude/software-ecology-pulse.md
@@ -146,23 +146,37 @@ Use this exact Markdown for the Linear status update and the Drive memo summary 
 
 **Release/rollback watch:** 1-3 bullets naming gaps or confirming no new gap.
 
-**Recommended clarification:** One small decision or proof target for humans.
+**Action items:** 1-4 ranked recommendations, highest priority first, each derived from the signals above (never invented). Format each as: `[P0|P1|P2]` imperative action or decision, then the repo, then the why / what it unblocks. Ranking: **P0** = a decision or fix needed before more agent work or before a risk compounds; **P1** = worth addressing this cycle; **P2** = minor or cosmetic. List only real items; if nothing is actionable, write `No action items this week.` These are recommendations for humans to act on, not work to file — the create-no-work guardrails still hold (no Issues, no Customer Needs).
 
 **No automatic work created:** Confirm that this run created no Issues, Customer Needs, projects, GitHub artifacts, repo edits, deploys, browser sessions, or `.plans` changes.
 ```
 
 Transition note: if the most recent prior status update on the initiative was produced from an uploaded snapshot (any update whose Snapshot line says "Generated at" rather than "Computed in-session"), include one line in the System read: "Metrics rebased: computed in-cloud from clones; not directly comparable to snapshot-era counts." Omit it once prior updates are already in the computed format.
 
-The Discord summary must be shorter:
+The Discord summary is a scannable lead-council read — fuller than a teaser, shorter than the full status update. Use this exact shape (normally one message, comfortably under Discord's 2000-char limit; if it ever exceeds 2000, split on a section boundary and POST the chunks sequentially):
 
 ```md
-**Software Ecology Pulse - YYYY-WW:** `health`
-One-sentence system read.
-- Strongest signal: ...
-- Watch: ...
-- Recommended clarification: ...
-No automatic work created.
+**Software Ecology Pulse · YYYY-WW · `health`** · coverage `N/3` · git: `full|partial`
+
+2-3 sentence system read using the run's actual numbers (name the one thing most worth a human's attention).
+
+**Holding up**
+- Concrete strong signal, with the number.
+- Concrete strong signal.
+
+**Watch**
+- Repo-tagged risk, with the why.
+- Repo-tagged risk.
+
+**Action items**
+1. `[P0|P1]` Action or decision — repo, the why / what it unblocks.
+2. `[P1]` Action — repo.
+
+Full analysis → <Linear status-update URL>
+No work created.
 ```
+
+The `Holding up` / `Watch` bullets are the 2 strongest entries from the status update's Strong signals / Risk signals. The `Action items` are the top 2-3 from the status update's Action items block, same ranking and wording, highest priority first (drop P2s here unless there is room). `Full analysis →` links the Linear status-update URL captured in the Write step so the reader can reach the complete analysis in one click.
 
 ## Write
 
@@ -171,8 +185,9 @@ No automatic work created.
    - Initiative: `Software Ecology & Agentic Workflow Health`
    - Health: selected rubric value
    - Body: status update Markdown
+   - Capture the returned status-update URL — the Discord post's `Full analysis →` line links it.
 2. Write a Drive memo titled `Software Ecology Pulse - YYYY-WW` in the Dev Guild shared Drive context.
-3. Post the short Discord summary to the private lead-council channel.
+3. Post the Discord summary (the medium format above, including the `Full analysis →` link to the step-1 status-update URL) to the private lead-council channel.
 
    **There is NO Discord MCP/connector in this environment — post via the Discord REST
    API with Bash + `curl`. Do NOT search for a Discord tool/connector, and do NOT


### PR DESCRIPTION
Follow-up to #28. afo's feedback: the output (especially the `#lead-council` Discord post) was too brief and not action-oriented. Two upgrades, **no scope/behavior/charter change** — still status-only, creates no work.

## Linear + Drive template
The single `Recommended clarification` line becomes a ranked **Action items** block:
- 1-4 items, highest priority first, each **derived from the signals above** (never invented).
- Format: `[P0|P1|P2]` action-or-decision — repo — why / what it unblocks.
- P0 = needed before more agent work or before a risk compounds; P1 = this cycle; P2 = minor/cosmetic.
- `No action items this week.` when nothing is actionable.
- **Recommendations only** — the create-no-work guardrails still hold (no Issues, no Customer Needs filed).

## Discord summary
The terse 3-bullet teaser becomes a scannable medium read:
- Header: `health · coverage N/3 · git visibility`
- 2-3 sentence system read with real numbers
- **Holding up** (2 strongest signals) · **Watch** (2 repo-tagged risks) · **Action items** (top 2-3, same ranking)
- `Full analysis →` link to the Linear status update (URL now captured in the Write step)
- Still one message under 2000 chars, with a section-boundary chunking fallback.

The Discord REST recipe + channel guard from #26 are preserved byte-identical.

Diff: +24 / -9, one file. After merge the live wrapper picks it up automatically (no trigger change); a manual test run will show the new format in `#lead-council`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)