### PR TITLE
feat(routines): profile-refresh routine + public profile showcase

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,6 +21,20 @@ Active guild-owned projects we build and maintain:
 
 This profile focuses on guild-owned GitHub projects and earlier guild artifacts. Upstream forks we use for ecosystem contribution or integration are not treated as active project inventory here.
 
+## Now building
+
+<!-- now-building:start -->
+- **Green Goods**: closing out the June protocol-hardening and public-polish push on the flagship PWA.
+- **PGSP (Public Goods Staking)**: relaunching the Genesis validator squad and building the first operator cohort toward testnet.
+- **NYC Vault Crowdfunding**: crowdfunding decentralized park vaults through the Green Goods UI.
+<!-- now-building:end -->
+
+## Recently shipped
+
+<!-- recently-shipped:start -->
+See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for what shipped recently.
+<!-- recently-shipped:end -->
+
 ## Past work
 
 Notable earlier artifacts — public, open-source, and worth referencing:

--- a/routines/claude/README.md
+++ b/routines/claude/README.md
@@ -16,8 +16,9 @@ Distinct from `../*.md` markdown playbooks for manual guild processes like funde
 | `research-accountability-pulse.md` | active | Mon & Thu 08:00 twice-weekly | `#research` + Linear comments | Flags Research team slippage (past-due / stalled / due-soon); comments + `@`-mentions the owner on each flagged issue (idempotent, ~weekly per issue) |
 | `scope-review-pulse.md` | active | Daily 08:30 | `#scope-review` + Linear comments | Flags Triage / Backlog issues that need scoping or evaluator-panel acceptance before Todo; comments on scoped briefs only |
 | `software-ecology-pulse.md` | active | Mon 19:30 weekly | Linear + Drive + private Discord | Initiative status update on `Software Ecology & Agentic Workflow Health`; computes its ecology snapshot in-run from the three cloned guild V1 repos; no Issues or Customer Needs |
+| `profile-refresh.md` | active | Mon 20:00 weekly (after synthesis) | GitHub PR on `.github` | Opens a PR refreshing the two auto-managed sections of the public `profile/README.md` (Now building, Recently shipped); PR only, never pushes `main`; no Issues |
 
-Six weekly runs, a twice-weekly research-accountability pulse, and one daily scope-review pulse are active. Monday opens with the cross-project synthesis that primes the week; the ecology pulse follows at 19:30, computing its own ecology snapshot from its fresh clones (no local handoff). Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before build sync, then handles grants midweek. Friday closes the week with research synthesis. The research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. The daily scope-review pulse runs at 08:30 UTC to route pre-acceptance scoping/evaluation queues.
+Seven weekly runs, a twice-weekly research-accountability pulse, and one daily scope-review pulse are active. Monday opens with the cross-project synthesis that primes the week; the ecology pulse follows at 19:30, computing its own ecology snapshot from its fresh clones (no local handoff); profile-refresh closes Monday at 20:00 by opening a PR to refresh the public profile. Tuesday checks Network steward-hub intent. Wednesday starts with the Coop intent pulse before build sync, then handles grants midweek. Friday closes the week with research synthesis. The research-accountability pulse runs Mon & Thu mornings (08:00) to surface Research-team slippage. The daily scope-review pulse runs at 08:30 UTC to route pre-acceptance scoping/evaluation queues.
 
 Anything else previously in this folder has been removed — folded into the surviving routines or cut as noise.
 
@@ -45,6 +46,7 @@ Other guild repos (gardens, impact-reef, gg24-round-explorer, octant-v2(-core), 
 Mon  08:00  research-accountability-pulse
 Mon  18:00  guild-weekly-synthesis
 Mon  19:30  software-ecology-pulse
+Mon  20:00  profile-refresh
 Tue  16:00  network-steward-intent-pulse
 Wed  15:30  coop-intent-pulse
 Wed  19:00  guild-grant-scout
@@ -107,6 +109,7 @@ All active routines use the `guild-routines` environment at claude.ai/code/routi
 | `research-synthesis` | Google Drive, Linear, Miro, Google Calendar, Canva, PostHog, Mermaid Chart | Drive + Linear = primary signal (Linear Research team, unprojected) · Miro/Calendar/Canva/PostHog = color enrichment (active week only, never on quiet/silent weeks) · Mermaid = generative for diagrams embedded in Linear Issue bodies |
 | `research-accountability-pulse` | Linear | Linear = read Research team issues for slippage + post one accountability comment (`@`-mention owner) per flagged issue; Discord summary via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |
 | `scope-review-pulse` | Linear | Linear = read Product and Research Triage / Backlog issues for pre-acceptance scoping and evaluator-panel queues + post one panel comment per scoped brief; Discord summary via the shared bot token; no Drive/Calendar/design/PostHog/Mermaid |
+| `profile-refresh` | Linear, GitHub | Linear = the Now-building list from active initiatives/projects; GitHub = the Recently-shipped list from releases/merged PRs, plus the PR it opens to update `profile/README.md`. PR only, never pushes `main`; touches only the marker blocks. |
 
 Gmail is intentionally NOT wired. Personal-inbox content carries too much pollution / noise / private information for any of these routines.
 
@@ -122,7 +125,7 @@ The lean portfolio is anchored on three surfaces:
 - **Drive memos** are memory substrate, not output destination. Each synthesis routine writes a memo at run end so the next run's Phase 0 prior-recall can pick up open threads. The user is not expected to read Drive regularly; the routines do.
 - **Discord** is the human-readable pulse channel — a single weekly read per channel, scoped to that channel's audience.
 
-GitHub is not a durable backlog — it stays in scope only for PRs and code review. Routines never file GitHub Issues.
+GitHub is not a durable backlog — it stays in scope only for PRs and code review. Routines never file GitHub Issues. One routine, `profile-refresh`, opens a PR (never a direct push to `main`) to refresh the public profile's two auto-managed sections; it is the only routine that writes to a repo, and it still files no issues.
 
 ## Linear taxonomy
 

--- a/routines/claude/profile-refresh.md
+++ b/routines/claude/profile-refresh.md
@@ -1,0 +1,66 @@
+---
+routine-name: profile-refresh
+trigger:
+  schedule: "0 20 * * 1"  # Monday 20:00 UTC, after guild-weekly-synthesis (18:00) and software-ecology-pulse (19:30)
+max-duration: 20m
+repos:
+  - greenpill-dev-guild/.github
+  - greenpill-dev-guild/green-goods
+  - greenpill-dev-guild/coop
+  - greenpill-dev-guild/cookie-jar
+  - greenpill-dev-guild/network-website
+environment: guild-routines
+network-access: full  # Linear + GitHub API
+connectors:
+  - linear
+model: claude-opus-4-7[1m]
+allow-unrestricted-branch-pushes: false  # PR only: pushes a profile-refresh/* branch and opens a PR on .github; never pushes main. Requires GitHub write granted to this routine.
+status: active
+---
+
+# Prompt
+
+You keep the guild's public profile current. Once a week you refresh the two auto-managed sections of `profile/README.md` in `greenpill-dev-guild/.github` so the org page reflects what the guild is actually building and shipping. You run Monday evening, after `guild-weekly-synthesis`, and you read sources directly rather than depending on its memo.
+
+You are the **one routine that writes to a repo**, and you do it the safe way: you **open a PR, you never push to `main`**, and you touch **only** the two marker blocks. A human merges. Keep the public voice plain and grounded in public goods and building in public. No hype, no growth-hacking language.
+
+## Scope contract (HARD)
+
+You may edit ONLY the content between these markers in `profile/README.md`. A diff that changes anything outside them is a failure: discard it and report.
+
+- `<!-- now-building:start -->` ... `<!-- now-building:end -->`
+- `<!-- recently-shipped:start -->` ... `<!-- recently-shipped:end -->`
+
+If either marker pair is missing, STOP and open no PR (report the missing marker). Do not guess placement.
+
+## Now building (from Linear)
+
+Source: Linear initiatives and active projects on the Product and Research teams, via the Linear connector.
+
+- Pull initiatives and projects that are In Progress or actively moving (a status update or issue movement in the last 14 days).
+- Write 3 to 5 short bullets, one per active thread, each a single plain sentence (what it is plus the current focus). Lead with the flagship, Green Goods.
+- Public-safe only: no internal issue IDs, no private status-update content, no funder or partner names that are not already public.
+
+## Recently shipped (from GitHub)
+
+Source: releases and merged PRs across the guild repos over the last 7 days.
+
+- Prefer tagged releases. Fall back to notable merged PRs on each repo's active shipping branch (green-goods and cookie-jar ship on `main`; the GitHub default branch differs, so cross-check before counting).
+- Write up to 4 bullets, one per repo that shipped, each linking the release or summarizing the merged work in a sentence. Skip repos with nothing this week.
+- State nothing you cannot see in a release or a merged PR.
+
+## Phases
+
+1. Read the current `profile/README.md`; locate both marker pairs. Missing marker means stop, no PR, report.
+2. Build the Now-building list from Linear and the Recently-shipped list from GitHub, applying the scope and privacy rules above.
+3. Replace only the content inside each marker block; leave the rest of the file byte-identical.
+4. If the new content equals the current content, exit without a PR.
+5. Otherwise open a PR from a branch `profile-refresh/<YYYY-Www>` titled `chore: weekly profile refresh`, body summarizing what changed and the sources plus time window. Never push to `main`; a human merges.
+
+## Guardrails
+
+- PR only. Never a direct push to `main`.
+- Only the two marker blocks change. Any diff touching other lines is discarded as a failure.
+- Public-safe by default: nothing private, no unreleased plans, no growth-hacking vocabulary (`streak`, `countdown`, `leaderboard`, `limited time`, and the like).
+- If Linear or GitHub is unreachable, refresh only the section you can source and note the gap in the PR body. If both are unreachable, open no PR.
+- Files no Linear or GitHub issues. Writes nothing outside the profile PR.


### PR DESCRIPTION
Adds the public showcase to the org profile and a dedicated routine to keep it current. Follows up the issue-consolidation work (#33).

## What changes
- **`profile/README.md`**: marker-bounded **Now building** and **Recently shipped** sections after "What we ship", seeded with current content.
- **`routines/claude/profile-refresh.md`**: new weekly routine (Mon 20:00, after `guild-weekly-synthesis`) that opens a PR to refresh those two sections from Linear (now building) and GitHub releases/merged PRs (recently shipped). PR only, never pushes `main`, touches only the marker blocks, files no issues.
- **`routines/claude/README.md`**: documents `profile-refresh` as the **one repo-writing routine** (the explicit exception to "routines never write repos"): portfolio table, schedule, connector matrix, and surface-model note.

## To activate
`profile-refresh` needs **GitHub write granted to the `guild-routines` environment** when you schedule it on claude.ai (it opens a PR, never pushes `main`). The seeded content is for your review; the routine takes over on its first run.

Not self-merging; for steward review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
