### PR TITLE
chore: weekly profile refresh

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@ This profile focuses on guild-owned GitHub projects and earlier guild artifacts.
 <!-- recently-shipped:start -->
 - **Green Goods**: restored Cookie Jar wallet sign-in on the public `/cookies` route so wallet auth persists after connecting ([#572](https://github.com/greenpill-dev-guild/green-goods/pull/572)).
 - **coop**: hardened local-first sync to reject invalid remote updates instead of persisting corrupted state, plus a more resilient invite handoff ([#19](https://github.com/greenpill-dev-guild/coop/pull/19)).
-- **network-website**: prepared the public home map for live chapter, steward, and member activity ahead of a production launch ([#10](https://github.com/greenpill-dev-guild/network/pull/10)).
+- **network-website**: prepared the public home map for live chapter, steward, and member activity ahead of a production launch ([#10](https://github.com/greenpill-dev-guild/network-website/pull/10)).
 <!-- recently-shipped:end -->
 
 ## Past work

--- a/profile/README.md
+++ b/profile/README.md
@@ -32,7 +32,9 @@ This profile focuses on guild-owned GitHub projects and earlier guild artifacts.
 ## Recently shipped
 
 <!-- recently-shipped:start -->
-See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for what shipped recently.
+- **Green Goods**: restored Cookie Jar wallet sign-in on the public `/cookies` route so wallet auth persists after connecting ([#572](https://github.com/greenpill-dev-guild/green-goods/pull/572)).
+- **coop**: hardened local-first sync to reject invalid remote updates instead of persisting corrupted state, plus a more resilient invite handoff ([#19](https://github.com/greenpill-dev-guild/coop/pull/19)).
+- **network-website**: prepared the public home map for live chapter, steward, and member activity ahead of a production launch ([#10](https://github.com/greenpill-dev-guild/network/pull/10)).
 <!-- recently-shipped:end -->
 
 ## Past work


### PR DESCRIPTION
Weekly auto-refresh of `profile/README.md` by the `profile-refresh` routine. Only the marker-bounded auto-managed sections may change; a human merges.

## What changed

**Recently shipped** — replaced the static "see releases" placeholder with the work that merged in the last 7 days (2026-06-15 → 2026-06-22). No tagged releases landed in the window, so these are notable merged PRs on each repo's active shipping branch (`main`):

- **Green Goods** — restored Cookie Jar wallet sign-in on the public `/cookies` route (green-goods#572, merged 2026-06-16).
- **coop** — hardened local-first sync to reject invalid remote updates instead of persisting corrupted state, plus a more resilient invite handoff (coop#19, merged 2026-06-19).
- **network-website** — prepared the public home map for live chapter/steward/member activity ahead of a production launch (network#10, merged 2026-06-17).

`cookie-jar` had no merges into its shipping branch this week, so it is omitted.

**Now building** — left unchanged this run. The Linear connector did not surface in this session, so I could not source live initiative/project state. Per the routine guardrail, I refreshed only the section I could source and left the Now-building block byte-identical rather than guess.

## Sources & window

- Recently shipped: GitHub releases + merged PRs across the guild repos, window 2026-06-15 → 2026-06-22 (last 7 days).
- Now building: Linear (Product + Research) — **unreachable this run**, section untouched.

## Scope

Only the content between the `recently-shipped` markers changed. The `now-building` markers and every other line are byte-identical to `main`. PR only — no direct push to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6ePay1JYCjTSLuoXTUMN)_