### PR TITLE
chore: weekly profile refresh

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,15 +24,16 @@ This profile focuses on guild-owned GitHub projects and earlier guild artifacts.
 ## Now building
 
 <!-- now-building:start -->
-- **Green Goods**: closing out the June protocol-hardening and public-polish push on the flagship PWA.
-- **PGSP (Public Goods Staking)**: relaunching the Genesis validator squad and building the first operator cohort toward testnet.
-- **NYC Vault Crowdfunding**: crowdfunding decentralized park vaults through the Green Goods UI.
+- **Green Goods**: finishing the protocol-hardening and public-polish push on the flagship PWA — QA and release hardening plus editorial and docs polish — as the project moves to a monthly release cadence.
+- **PGSP (Public Goods Staking)**: re-paced operator-first — getting the guild's own nodes and squad solid now, with the Genesis squad relaunch and first operator cohort onboarding next.
+- **Greenpill Network website**: polishing the public site and onboarding stewards so the community map and content stay accurate after the June launch.
+- **Impact Framework**: refreshing the Greenpill impact methodology into current Green Goods evidence, evaluator, and funder language.
 <!-- now-building:end -->
 
 ## Recently shipped
 
 <!-- recently-shipped:start -->
-See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for what shipped recently.
+- **[green-goods](https://github.com/greenpill-dev-guild/green-goods/pulls?q=is%3Apr+is%3Amerged)**: merged a week of release-hardening on the flagship PWA — a USD/wETH toggle on the `/fund` funding flow, a full-screen admin Submit Work flow, hardened vault crowdfunding, and time-boxed media uploads so weak-signal photo uploads fail retryably instead of hanging.
 <!-- recently-shipped:end -->
 
 ## Past work


### PR DESCRIPTION
Weekly refresh of the two auto-managed sections of `profile/README.md`. Only the content inside the `now-building` and `recently-shipped` marker blocks changed; the rest of the file is byte-identical. A human merges.

## Now building (source: Linear — Product + Research, In Progress / moved in the last ~14 days)

- **Green Goods**: reworded to reflect the active protocol-hardening + polish push (QA/release hardening + Public Website & Docs Polish projects In Progress) and the move to a monthly release cadence.
- **PGSP**: updated from "relaunching the Genesis validator squad" to the operator-first re-pace (re-paced 2026-06-19) — node setup now, Genesis squad relaunch + first operator cohort next.
- **Greenpill Network website**: new bullet — the *Website Polish & Steward Onboarding* project is In Progress under the Network Presence initiative.
- **Impact Framework**: new bullet — *Impact Framework v0.1 Refresh* (Research) is In Progress.
- **Removed NYC Vault Crowdfunding** — the Linear project was marked **Completed on 2026-06-29**, so it no longer belongs in "now building."

## Recently shipped (source: GitHub — last 7 days, 2026-06-22 → 06-29)

- **green-goods** is the only repo with merges in the window: a USD/wETH toggle on the `/fund` flow, a full-screen admin Submit Work flow, hardened vault crowdfunding, and time-boxed media uploads. Replaces the old static "see releases" placeholder (there are no tagged releases yet; first cadenced release is July).

### Gaps / notes
- **No tagged releases** exist on any repo, so the shipped bullet summarizes merged PRs.
- **coop** (last merge 2026-06-19), **network-website** (last merge 2026-06-17): nothing merged in the 7-day window, so they're omitted per the skip-empty rule.
- **cookie-jar**: the GitHub PR-list endpoint returned 404 (no accessible PRs); nothing to report this week.
- green-goods merges land on `develop`; wording says "merged" rather than "deployed" since the first production release is scheduled for July.

Public-safe: no internal issue IDs, no private status-update content, no non-public partner/funder names. No growth-hacking vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1nqUMKVKbyZAL1z99jWsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1nqUMKVKbyZAL1z99jWsH)_