### PR TITLE
chore: weekly profile refresh

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,15 +22,20 @@ This profile focuses on guild-owned GitHub projects and earlier guild artifacts.
 ## Now building
 
 <!-- now-building:start -->
-- **Green Goods**: closing out the June protocol-hardening and public-polish push on the flagship PWA.
-- **PGSP (Public Goods Staking)**: relaunching the Genesis validator squad and building the first operator cohort toward testnet.
-- **NYC Vault Crowdfunding**: crowdfunding decentralized park vaults through the Green Goods UI.
+- **Green Goods**: hardening and polishing the flagship offline-first PWA — QA and release hardening across admin, client, and wallet flows, plus a public website and docs refresh.
+- **Greenpill Network website**: polishing the public site and community map after the June launch and onboarding stewards so chapter and steward content stays accurate.
+- **PGSP (Public Goods Staking)**: an operator-first relaunch — standing up the Genesis validator squad and node setup to prepare operators for testnet onboarding.
+- **Commitment pooling**: designing durable per-garden commitment pools so promises can be seeded, fulfilled through the work flow, and rewarded.
+- **Impact methodology**: refreshing the Greenpill impact framework and evaluator workflows to keep garden evidence legible for funders and communities.
 <!-- now-building:end -->
 
 ## Recently shipped
 
 <!-- recently-shipped:start -->
-See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for what shipped recently.
+- [**green-goods**](https://github.com/greenpill-dev-guild/green-goods): kept the shared component library's Storybook interaction tests running offline in CI so the component test gate stays reliable ([#629](https://github.com/greenpill-dev-guild/green-goods/pull/629)).
+- [**.github**](https://github.com/greenpill-dev-guild/.github): streamlined the guild's automation routines — narrowed their scope to the active repos and gave the weekly Discord updates a consistent, readable format ([#39](https://github.com/greenpill-dev-guild/.github/pull/39)).
+
+See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for the full changelog.
 <!-- recently-shipped:end -->
 
 ## Past work


### PR DESCRIPTION
Weekly `profile-refresh` run for **2026-W28** (window: now-building from Linear over the last 14 days; recently-shipped from GitHub over the last 7 days, 2026-06-29 → 2026-07-06). Only the two marker-bounded blocks in `profile/README.md` changed — everything else is byte-identical.

## Now building — from Linear (Product + Research, active/moving in last 14 days)
- Added **Greenpill Network website** (Network Presence — website polish + steward onboarding, In Progress), **Commitment pooling** (durable per-garden commitment pools, actively moving), and **Impact methodology** (impact-framework/evaluator refresh, In Progress).
- Reframed the **Green Goods** bullet to the current hardening + public-website/docs polish focus.
- Kept **PGSP** (operator-first squad relaunch).
- **Removed NYC Vault Crowdfunding** — that project is now `Completed` in Linear (closed 2026-06-29), so it no longer belongs under "now building."

## Recently shipped — from GitHub (merged to shipping branches, last 7 days)
No tagged releases this week, so this falls back to merged PRs on each repo's shipping branch:
- **green-goods** (`main`): [#629](https://github.com/greenpill-dev-guild/green-goods/pull/629) — Storybook interaction tests kept offline in CI (merged 2026-07-05; the only merge to `main` in-window).
- **.github** (`main`): [#39](https://github.com/greenpill-dev-guild/.github/pull/39) — guild automation routines revamp (merged 2026-07-05).
- **network-website** (`network`): nothing merged in-window (last ship was #10 on 2026-06-17) — skipped.

## Guardrails
- PR only; no push to `main` — a human merges.
- Diff confined to the `now-building` and `recently-shipped` marker blocks (verified with `git diff`).
- Public-safe: no internal issue IDs, no private status-update content, no non-public partner/funder names; every recently-shipped claim maps to a merged PR.
- Both Linear and GitHub were reachable this run.


---
_Generated by [Claude Code](https://claude.ai/code/session_017j4HjXX88QF4nQSUboP5fH)_