### PR TITLE
chore: weekly profile refresh

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,15 +22,18 @@ This profile focuses on guild-owned GitHub projects and earlier guild artifacts.
 ## Now building
 
 <!-- now-building:start -->
-- **Green Goods**: closing out the June protocol-hardening and public-polish push on the flagship PWA.
-- **PGSP (Public Goods Staking)**: relaunching the Genesis validator squad and building the first operator cohort toward testnet.
-- **NYC Vault Crowdfunding**: crowdfunding decentralized park vaults through the Green Goods UI.
+- **Green Goods**: the flagship regen-documentation PWA is now on a monthly release cadence — v1.2.0 shipped in July, with the August v1.3.0 cut and rolling QA the current focus.
+- **Public Goods Staking (PGSP)**: an operator-first relaunch — standing up the Genesis validator squad and first operator cohort on the path to testnet.
+- **Greenpill Network website**: polishing the public site and community map after June's launch, and onboarding stewards so the map and content stay accurate.
+- **Commitment Pooling**: building durable per-garden commitment pools that link community requests, offers, accepted work, and evidence into one confirmable on-chain thread.
+- **Community Needs & Signals**: an independent community app for naming requests, offers, and initiatives and following a legible need-to-proof thread.
 <!-- now-building:end -->
 
 ## Recently shipped
 
 <!-- recently-shipped:start -->
-See [Green Goods releases](https://github.com/greenpill-dev-guild/green-goods/releases) for what shipped recently.
+- **Green Goods**: shipped [v1.2.0](https://github.com/greenpill-dev-guild/green-goods/releases/tag/v1.2.0) in July — a monthly release hardening the PWA and passkey recovery, overhauling the admin dialog system, polishing the funding flows, and migrating signup to Resend.
+- **Greenpill Network website**: merged public-map improvements this week — steward profiles now project from the CMS, moderators are alerted to pending map submissions, and map location handling was hardened. See [merged work](https://github.com/greenpill-dev-guild/network-website/pulls?q=is%3Apr+is%3Amerged).
 <!-- recently-shipped:end -->
 
 ## Past work


### PR DESCRIPTION
Weekly refresh of the two auto-managed marker blocks in `profile/README.md`. Only the content inside `now-building` and `recently-shipped` changed; every other line is byte-identical. A human merges — this branch never pushes `main`.

## Now building (source: Linear, active initiatives/projects, ~last 14 days)
- Green Goods — reframed from the closed June hardening push to the current monthly release cadence (v1.2.0 shipped, v1.3.0 + rolling QA now active).
- PGSP — carried forward (operator-first Genesis squad relaunch, still In Progress).
- Added **Greenpill Network website** (site + community-map polish and steward onboarding, In Progress).
- Added **Commitment Pooling** and **Community Needs & Signals** (both actively moving product builds).
- Dropped **NYC Vault Crowdfunding** — the vault crowdfunding flow shipped in v1.2.0 and has no standalone active project.

## Recently shipped (source: GitHub releases + merged PRs, 2026-07-06 → 2026-07-13)
- **green-goods** — tagged release [v1.2.0](https://github.com/greenpill-dev-guild/green-goods/releases/tag/v1.2.0), published 2026-07-08.
- **network-website** — 3 merged PRs this week on the public map (steward projection #11, pending-node moderator alerts #12, map-location integrity #13).
- **.github** — nothing merged inside the 7-day window (most recent was #39 on 2026-07-05), so no bullet.

Public-safe: no internal issue IDs, private status content, or non-public partner/funder names in the rendered profile. Both Linear and GitHub were reachable this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnH6pCbYd2iEHoNkUdKZJy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnH6pCbYd2iEHoNkUdKZJy)_